### PR TITLE
Add PSR-7 request wrapper

### DIFF
--- a/src/Request/Psr7.php
+++ b/src/Request/Psr7.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Acquia\Hmac\Request;
+
+use Psr\Http\Message\RequestInterface as Psr7RequestInterface;
+
+class Psr7 implements RequestInterface
+{
+    /**
+     * @var \Psr\Http\Message\RequestInterface
+     */
+    protected $request;
+
+    /**
+     * @param \Psr\Http\Message\RequestInterface $request
+     */
+    public function __construct(Psr7RequestInterface $request)
+    {
+        $this->request = $request;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function hasHeader($header)
+    {
+        return $this->request->hasHeader($header);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getHeader($header)
+    {
+        return $this->request->getHeaderLine($header);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getMethod()
+    {
+        return $this->request->getMethod();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getBody()
+    {
+        return $this->request->getBody();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getResource()
+    {
+        return $this->request->getRequestTarget();
+    }
+}

--- a/test/Psr7RequestTest.php
+++ b/test/Psr7RequestTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Acquia\Hmac\Test;
+
+use Acquia\Hmac\Request\Psr7;
+use GuzzleHttp\Psr7\Request;
+
+class Psr7RequestTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @return \Acquia\Hmac\Request\Psr7
+     */
+    public function getRequest(array $headers = array(), $method = 'GET')
+    {
+        $uri = 'http://example.com/resource/1?key=value';
+        return new Psr7(new Request($method, $uri, $headers));
+    }
+
+    public function testHasHeader()
+    {
+        $request = $this->getRequest(array('header' => 'value'));
+
+        $this->assertTrue($request->hasHeader('header'));
+        $this->assertFalse($request->hasHeader('missing'));
+    }
+
+    public function testGetHeader()
+    {
+        $request = $this->getRequest(array('header' => 'value'));
+
+        $this->assertEquals('value', $request->getHeader('header'));
+        $this->assertEmpty($request->getHeader('missing'));
+    }
+
+    public function testGetMethod()
+    {
+        $request1 = $this->getRequest(array(), 'GET');
+        $this->assertEquals('GET', $request1->getMethod());
+
+        $request2 = $this->getRequest(array(), 'POST');
+        $this->assertEquals('POST', $request2->getMethod());
+    }
+
+    public function testGetBody()
+    {
+        $request1 = $this->getRequest();
+        $this->assertEquals('', $request1->getBody());
+
+        $request2 = new Psr7(new Request('GET', 'http://example.com', [], 'test content'));
+        $this->assertEquals('test content', $request2->getBody());
+    }
+
+    public function testGetResource()
+    {
+        $request = $this->getRequest();
+        $this->assertEquals('/resource/1?key=value', $request->getResource());
+    }
+}


### PR DESCRIPTION
This adds a PSR-7-compliant request wrapper. The already-existing Guzzle request wrapper is nearly PSR-7 compliant so this is mostly just a copy of that with the ability to use the interface directly from the PSR.