### PR TITLE
Add Symfony/Silex integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,11 @@
         "psr/http-message": "~1.0.0"
     },
     "suggest": {
-        "guzzlehttp/guzzle": "~6.0"
+        "guzzlehttp/guzzle": "~6.0",
+        "silex/silex": "~1.3.0",
+        "symfony/psr-http-message-bridge": "~0.1.0",
+        "symfony/security": "~3.0.0",
+        "zendframework/zend-diactoros": "~1.3.5"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "~6.0",
@@ -28,7 +32,11 @@
         "phpunit/phpunit": "~3.0",
         "scrutinizer/ocular": "~1.0",
         "sebastian/phpcpd": "~2.0",
-        "squizlabs/php_codesniffer": "^2.3"
+        "silex/silex": "~1.3.0",
+        "squizlabs/php_codesniffer": "^2.3",
+        "symfony/psr-http-message-bridge": "~0.1.0",
+        "symfony/security": "~3.0.0",
+        "zendframework/zend-diactoros": "~1.3.5"
     },
     "replace": {
         "acquia/hmac-request": "self.version"

--- a/src/Symfony/HmacAuthenticationEntryPoint.php
+++ b/src/Symfony/HmacAuthenticationEntryPoint.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Acquia\Hmac\Symfony;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+
+/**
+ * Response handling for a client making an unauthenticated request.
+ */
+class HmacAuthenticationEntryPoint implements AuthenticationEntryPointInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        $response = new Response();
+        $response->setStatusCode(401, $authException ? $authException->getMessage() : null);
+
+        return $response;
+    }
+}

--- a/src/Symfony/HmacAuthenticationListener.php
+++ b/src/Symfony/HmacAuthenticationListener.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Acquia\Hmac\Symfony;
+
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+use Symfony\Component\Security\Http\Firewall\ListenerInterface;
+
+/**
+ * Handles an authentication event.
+ */
+class HmacAuthenticationListener implements ListenerInterface
+{
+    /**
+     * @var \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface
+     *   Stores a security token for authentication.
+     */
+    protected $tokenStorage;
+
+    /**
+     * @var \Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface
+     *   Manages the available authentication providers.
+     */
+    protected $authManager;
+
+    /**
+     * @var \Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface
+     *   Response handling for a client making an unauthenticated request.
+     */
+    protected $entryPoint;
+
+    /**
+     * Initializes the authentication listener.
+     *
+     * @param \Symfony\Component\Security\Csrf\TokenStorage\TokenStorageInterface $tokenStorage
+     *   Storage for a security token during authentication.
+     * @param \Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface $authManager
+     *   An authentication provider manager.
+     * @param \Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface $entryPoint
+     *   An entry point for unauthenticated client requests.
+     */
+    public function __construct(TokenStorageInterface $tokenStorage, AuthenticationManagerInterface $authManager, AuthenticationEntryPointInterface $entryPoint)
+    {
+        $this->tokenStorage = $tokenStorage;
+        $this->authManager = $authManager;
+        $this->entryPoint = $entryPoint;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function handle(GetResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        // Requests require an Authorization header.
+        if (!$request->headers->has('Authorization')) {
+            $event->setResponse($this->entryPoint->start($request));
+            return;
+        }
+
+        $token = new HmacToken($request);
+
+        try {
+            $authToken = $this->authManager->authenticate($token);
+            $this->tokenStorage->setToken($authToken);
+            $request->attributes->set('hmac.key', $authToken->getCredentials());
+        } catch (AuthenticationException $e) {
+            $event->setResponse($this->entryPoint->start($request, $e));
+        }
+    }
+}

--- a/src/Symfony/HmacAuthenticationProvider.php
+++ b/src/Symfony/HmacAuthenticationProvider.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Acquia\Hmac\Symfony;
+
+use Acquia\Hmac\RequestAuthenticatorInterface;
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Provides the means to authenticate an HTTP HMAC request.
+ */
+class HmacAuthenticationProvider implements AuthenticationProviderInterface
+{
+    /**
+     * @var \Acquia\Hmac\RequestAuthenticatorInterface
+     *   A HMAC request authenticator service.
+     */
+    protected $authenticator;
+
+    /**
+     * Initializes the authentication provider.
+     *
+     * @param \Acquia\Hmac\RequestAuthenticatorInterface $authenticator
+     *   The HMAC request authenticator service.
+     */
+    public function __construct(RequestAuthenticatorInterface $authenticator)
+    {
+        $this->authenticator = $authenticator;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function authenticate(TokenInterface $token)
+    {
+        $psr7Factory = new DiactorosFactory();
+        $psr7Request = $psr7Factory->createRequest($token->getRequest());
+
+        try {
+            $key = $this->authenticator->authenticate($psr7Request);
+
+            return new HmacToken($token->getRequest(), $key);
+        } catch (\Exception $e) {
+            throw new AuthenticationException($e->getMessage());
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports(TokenInterface $token)
+    {
+        return $token instanceof HmacToken;
+    }
+}

--- a/src/Symfony/HmacResponseListener.php
+++ b/src/Symfony/HmacResponseListener.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Acquia\Hmac\Symfony;
+
+use Acquia\Hmac\ResponseSigner;
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Signs the response from an HTTP HMAC-authenticated request.
+ */
+class HmacResponseListener implements EventSubscriberInterface
+{
+    /**
+     * @param FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        if (!$event->isMasterRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $response = $event->getResponse();
+
+        if ($request->attributes->has('hmac.key')) {
+            $psr7Factory = new DiactorosFactory();
+            $foundationFactory = new HttpFoundationFactory();
+
+            $psr7Request = $psr7Factory->createRequest($request);
+            $psr7Response = $psr7Factory->createResponse($response);
+
+            $signer = new ResponseSigner($request->attributes->get('hmac.key'), $psr7Request);
+            $signedResponse = $signer->signResponse($psr7Response);
+
+            $event->setResponse($foundationFactory->createResponse($signedResponse));
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [KernelEvents::RESPONSE => 'onKernelResponse'];
+    }
+}

--- a/src/Symfony/HmacSecurityProvider.php
+++ b/src/Symfony/HmacSecurityProvider.php
@@ -42,11 +42,11 @@ class HmacSecurityProvider implements ServiceProviderInterface
 
         $app['security.authentication_listener.factory.hmac'] = $app->protect(function ($name, $options) use ($app) {
 
-            if (!isset($app['security.authentication_provider.' . $name . '.hamc'])) {
+            if (!isset($app['security.authentication_provider.' . $name . '.hmac'])) {
                 $app['security.authentication_provider.' . $name . '.hmac'] = $app['security.authentication_provider.hmac._proto']($name, $options);
             }
 
-            if (!isset($app['security.authentication_listener.' . $name . '.hamc'])) {
+            if (!isset($app['security.authentication_listener.' . $name . '.hmac'])) {
                 $app['security.authentication_listener.' . $name . '.hmac'] = $app['security.authentication_listener.hmac._proto']($name, $options);
             }
 

--- a/src/Symfony/HmacSecurityProvider.php
+++ b/src/Symfony/HmacSecurityProvider.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Acquia\Hmac\Symfony;
+
+use Acquia\Hmac\KeyLoaderInterface;
+use Acquia\Hmac\RequestAuthenticator;
+use Acquia\Hmac\Symfony\HmacAuthenticationEntryPoint;
+use Acquia\Hmac\Symfony\HmacAuthenticationListener;
+use Acquia\Hmac\Symfony\HmacAuthenticationProvider;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Acquia\Hmac\Symfony\HmacResponseListener;
+
+/**
+ * A Silex service provider to provide Acquia HTTP Hmac as a firewall option.
+ */
+class HmacSecurityProvider implements ServiceProviderInterface
+{
+    /**
+     * @var \Acquia\Hmac\KeyLoaderInterface
+     *   An HMAC key loader.
+     */
+    protected $keyLoader;
+
+    /**
+     * Initializes the security provider.
+     *
+     * @param \Acquia\Hmac\KeyLoaderInterface $keyLoader
+     *   An HMAC key loader.
+     */
+    public function __construct(KeyLoaderInterface $keyLoader)
+    {
+        $this->keyLoader = $keyLoader;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function register(Application $app)
+    {
+        $keyLoader = $this->keyLoader;
+
+        $app['security.authentication_listener.factory.hmac'] = $app->protect(function ($name, $options) use ($app) {
+
+            if (!isset($app['security.authentication_provider.' . $name . '.hamc'])) {
+                $app['security.authentication_provider.' . $name . '.hmac'] = $app['security.authentication_provider.hmac._proto']($name, $options);
+            }
+
+            if (!isset($app['security.authentication_listener.' . $name . '.hamc'])) {
+                $app['security.authentication_listener.' . $name . '.hmac'] = $app['security.authentication_listener.hmac._proto']($name, $options);
+            }
+
+            if (!isset($app['security.entry_point.' . $name . '.hamc'])) {
+                $app['security.entry_point.' . $name . '.hmac'] = $app['security.entry_point.hmac._proto']($name, $options);
+            }
+
+            return [
+                'security.authentication_provider.' . $name . '.hmac',
+                'security.authentication_listener.' . $name . '.hmac',
+                'security.entry_point.' . $name . '.hmac',
+                'pre_auth',
+            ];
+        });
+
+        $app['security.hmac.response_listener'] = $app->share(function () {
+            return new HmacResponseListener();
+        });
+
+        $app['security.authentication_provider.hmac._proto'] = $app->protect(function($name, $options) use ($app, $keyLoader) {
+            return $app->share(function () use ($keyLoader) {
+                return new HmacAuthenticationProvider(new RequestAuthenticator($keyLoader));
+            });
+        });
+
+        $app['security.authentication_listener.hmac._proto'] = $app->protect(function($name, $options) use ($app) {
+            return $app->share(function () use ($app, $name) {
+                return new HmacAuthenticationListener(
+                    $app['security.token_storage'],
+                    $app['security.authentication_manager'],
+                    $app['security.entry_point.' . $name . '.hmac']
+                );
+            });
+        });
+
+        $app['security.entry_point.hmac._proto'] = $app->protect(function($name, $options) use ($app) {
+            return new HmacAuthenticationEntryPoint();
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function boot(Application $app)
+    {
+        if (!isset($app['security'])) {
+            throw new \LogicException('You must register the SecurityServiceProvider to use the HmacServiceProvider.');
+        }
+
+        $app['dispatcher']->addSubscriber($app['security.hmac.response_listener']);
+    }
+}

--- a/src/Symfony/HmacSecurityProvider.php
+++ b/src/Symfony/HmacSecurityProvider.php
@@ -50,7 +50,7 @@ class HmacSecurityProvider implements ServiceProviderInterface
                 $app['security.authentication_listener.' . $name . '.hmac'] = $app['security.authentication_listener.hmac._proto']($name, $options);
             }
 
-            if (!isset($app['security.entry_point.' . $name . '.hamc'])) {
+            if (!isset($app['security.entry_point.' . $name . '.hmac'])) {
                 $app['security.entry_point.' . $name . '.hmac'] = $app['security.entry_point.hmac._proto']($name, $options);
             }
 

--- a/src/Symfony/HmacToken.php
+++ b/src/Symfony/HmacToken.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Acquia\Hmac\Symfony;
+
+use Acquia\Hmac\KeyInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\AbstractToken;
+
+/**
+ * An authentication token for HTTP HMAC requests.
+ */
+class HmacToken extends AbstractToken
+{
+    /**
+     * @var \Symfony\Component\HttpFoundation\Request
+     *   The authenticated request.
+     */
+    protected $request;
+
+    /**
+     * @var \Acquia\Hmac\KeyInterface
+     *   The authenticated credentials.
+     */
+    protected $key;
+
+    /**
+     * Initializes the token.
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     *   The authenticated request.
+     * @param \Acquia\Hmac\KeyInterface $key
+     *   An optional set of authenticated credentials.
+     * @param \Symfony\Component\Security\Core\Role\RoleInterface[]|string[] $roles
+     *   An array of roles.
+     */
+    public function __construct(Request $request, KeyInterface $key = null, array $roles = [])
+    {
+        parent::__construct($roles);
+
+        $this->request = $request;
+        $this->key = $key;
+    }
+
+    /**
+     * Returns the authenticated request associated with the token.
+     *
+     * @return \Symfony\Component\HttpFoundation\Request
+     *   The authenticated request.
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getCredentials()
+    {
+        return $this->key;
+    }
+}

--- a/test/Symfony/HmacAuthenticationEntryPointTest.php
+++ b/test/Symfony/HmacAuthenticationEntryPointTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Acquia\Hmac\Test\Symfony;
+
+use Acquia\Hmac\Symfony\HmacAuthenticationEntryPoint;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * Tests the entry point for Symfony-based authentication.
+ */
+class HmacAuthenticationEntryPointTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Ensures the entry point response is set correctly.
+     */
+    public function testStart()
+    {
+        $responseMessage = 'This is a test message.';
+
+        $request = $this->getMock(Request::class);
+        $authException = new AuthenticationException($responseMessage);
+
+        $entryPoint = new HmacAuthenticationEntryPoint();
+
+        $response = $entryPoint->start($request, $authException);
+
+        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertContains($responseMessage, (string) $response);
+    }
+}

--- a/test/Symfony/HmacAuthenticationListenerTest.php
+++ b/test/Symfony/HmacAuthenticationListenerTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Acquia\Hmac\Test\Symfony;
+
+use Acquia\Hmac\Key;
+use Acquia\Hmac\KeyInterface;
+use Acquia\Hmac\Symfony\HmacAuthenticationListener;
+use Acquia\Hmac\Symfony\HmacToken;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Security\Core\Authentication\AuthenticationManagerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Symfony\Component\Security\Http\EntryPoint\AuthenticationEntryPointInterface;
+
+/**
+ * Tests the authentication listener for Symfony-based authentication.
+ */
+class HmacAuthenticationListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Ensures a request fails to authenticate without an Authorization header.
+     */
+    public function testRequiredAuthorizationHeader()
+    {
+        $kernel = $this->getMock(HttpKernelInterface::class);
+        $storage = $this->getMock(TokenStorageInterface::class);
+        $manager = $this->getMock(AuthenticationManagerInterface::class);
+        $entry = $this->getMock(AuthenticationEntryPointInterface::class, ['start']);
+
+        $entryResponse = new Response('Authentication failed', 401);
+        $entry->expects($this->any())
+            ->method('start')
+            ->will($this->returnValue($entryResponse));
+
+        $request  = new Request();
+        $event    = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $listener = new HmacAuthenticationListener($storage, $manager, $entry);
+
+        $listener->handle($event);
+
+        $this->assertTrue($event->hasResponse());
+        $this->assertEquals($entryResponse->getStatusCode(), $event->getResponse()->getStatusCode());
+        $this->assertEquals($entryResponse->getContent(), $event->getResponse()->getContent());
+    }
+
+    /**
+     * Ensures a request receives the auth key if authenticated properly.
+     */
+    public function testAuthentication()
+    {
+        $authId = 'efdde334-fe7b-11e4-a322-1697f925ec7b';
+        $authSecret = 'W5PeGMxSItNerkNFqQMfYiJvH14WzVJMy54CPoTAYoI=';
+
+        $kernel  = $this->getMock(HttpKernelInterface::class);
+        $storage = $this->getMock(TokenStorageInterface::class);
+        $manager = $this->getMock(AuthenticationManagerInterface::class);
+        $entry  = $this->getMock(AuthenticationEntryPointInterface::class);
+
+        $request   = new Request();
+        $response  = new Response();
+        $authKey   = new Key($authId, $authSecret);
+        $authToken = new HmacToken($request, $authKey);
+
+        $request->headers->set('Authorization', 'foo');
+
+        $manager->expects($this->any())
+            ->method('authenticate')
+            ->will($this->returnValue($authToken));
+
+        $event    = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $listener = new HmacAuthenticationListener($storage, $manager, $entry);
+
+        $event->setResponse($response);
+        $listener->handle($event);
+
+        $handledRequest = $event->getRequest();
+
+        $this->assertTrue($handledRequest->attributes->has('hmac.key'));
+
+        $key = $handledRequest->attributes->get('hmac.key');
+
+        $this->assertInstanceOf(KeyInterface::class, $key);
+        $this->assertEquals($authId, $key->getId());
+        $this->assertEquals($authSecret, $key->getSecret());
+    }
+
+    /**
+     * Ensures the response is correct if the request fails to authenticate.
+     */
+    public function testFailedAuthentication()
+    {
+        $kernel  = $this->getMock(HttpKernelInterface::class);
+        $storage = $this->getMock(TokenStorageInterface::class);
+        $manager = $this->getMock(AuthenticationManagerInterface::class);
+        $entry   = $this->getMock(AuthenticationEntryPointInterface::class);
+
+        $request       = new Request();
+        $entryResponse = new Response('Authentication failed', 401);
+
+        $request->headers->set('Authorization', 'foo');
+
+        $manager->expects($this->any())
+            ->method('authenticate')
+            ->will($this->throwException(new AuthenticationException('Authentication failed')));
+
+        $entry->expects($this->any())
+            ->method('start')
+            ->will($this->returnValue($entryResponse));
+
+        $event    = new GetResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST);
+        $listener = new HmacAuthenticationListener($storage, $manager, $entry);
+
+        $listener->handle($event);
+
+        $this->assertTrue($event->hasResponse());
+        $this->assertEquals($entryResponse->getStatusCode(), $event->getResponse()->getStatusCode());
+        $this->assertEquals($entryResponse->getContent(), $event->getResponse()->getContent());
+    }
+}

--- a/test/Symfony/HmacAuthenticationProviderTest.php
+++ b/test/Symfony/HmacAuthenticationProviderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Acquia\Hmac\Test\Symfony;
+
+use Acquia\Hmac\Key;
+use Acquia\Hmac\KeyInterface;
+use Acquia\Hmac\RequestAuthenticatorInterface;
+use Acquia\Hmac\Symfony\HmacAuthenticationProvider;
+use Acquia\Hmac\Symfony\HmacToken;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+
+/**
+ * Tests the Symfony authentication provider.
+ */
+class HmacAuthenticationProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Ensures the authentication provider creates a signed token if auth passes.
+     */
+    public function testAuthentication()
+    {
+        $authId     = 'efdde334-fe7b-11e4-a322-1697f925ec7b';
+        $authSecret = 'W5PeGMxSItNerkNFqQMfYiJvH14WzVJMy54CPoTAYoI=';
+
+        $authenticator = $this->getMock(RequestAuthenticatorInterface::class);
+
+        $request = Request::create('http://example.com');
+        $key     = new Key($authId, $authSecret);
+
+        $authenticator->expects($this->any())
+            ->method('authenticate')
+            ->will($this->returnValue($key));
+
+        $token    = new HmacToken($request);
+        $provider = new HmacAuthenticationProvider($authenticator);
+
+        $response = $provider->authenticate($token);
+
+        $this->assertInstanceOf(HmacToken::class, $response);
+        $this->assertInstanceOf(KeyInterface::class, $response->getCredentials());
+        $this->assertEquals($authId, $response->getCredentials()->getId());
+        $this->assertEquals($authSecret, $response->getCredentials()->getSecret());
+        $this->assertInstanceOf(Request::class, $response->getRequest());
+    }
+
+    /**
+     * Ensures the authentication provider throws an exception if auth fails.
+     *
+     * @expectedException \Symfony\Component\Security\Core\Exception\AuthenticationException
+     * @expectedExceptionMessage Authentication failed.
+     */
+    public function testAuthenticationFailed()
+    {
+        $authenticator = $this->getMock(RequestAuthenticatorInterface::class);
+
+        $authenticator->expects($this->any())
+            ->method('authenticate')
+            ->will($this->throwException(new \Exception('Authentication failed.')));
+
+        $request  = Request::create('http://example.com');
+        $token    = new HmacToken($request);
+        $provider = new HmacAuthenticationProvider($authenticator);
+
+        $provider->authenticate($token);
+    }
+
+    /**
+     * Ensures the authentication provider only supports HMAC tokens.
+     */
+    public function testSupportsHmacTokens()
+    {
+        $request       = $this->getMock(Request::class);
+        $authenticator = $this->getMock(RequestAuthenticatorInterface::class);
+
+        $provider  = new HmacAuthenticationProvider($authenticator);
+        $hmacToken = new HmacToken($request);
+        $anonToken = new AnonymousToken('foo', 'foo');
+
+        $this->assertTrue($provider->supports($hmacToken));
+        $this->assertFalse($provider->supports($anonToken));
+    }
+}

--- a/test/Symfony/HmacResponseListenerTest.php
+++ b/test/Symfony/HmacResponseListenerTest.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Acquia\Hmac\Test\Symfony;
+
+use Acquia\Hmac\Key;
+use Acquia\Hmac\Symfony\HmacResponseListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Tests the response listener for Symfony-based authentication.
+ */
+class HmacResponseListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Ensures the response listener listens to the correct events.
+     */
+    public function testGetSubsribedEvents()
+    {
+        $this->assertArrayHasKey(KernelEvents::RESPONSE, HmacResponseListener::getSubscribedEvents());
+    }
+
+    /**
+     * Ensures the response listener only responds to the main request.
+     */
+    public function testSubRequestsAreIgnored()
+    {
+        $kernel   = $this->getMock(HttpKernelInterface::class);
+        $request  = $this->getMock(Request::class);
+        $response = $this->getMock(Response::class);
+
+        $event    = new FilterResponseEvent($kernel, $request, HttpKernelInterface::SUB_REQUEST, $response);
+        $listener = new HmacResponseListener();
+
+        $listener->onKernelResponse($event);
+
+        $this->assertSame($response, $event->getResponse());
+    }
+
+    /**
+     * Ensures the response listener only responds to HMAC-tagged requests.
+     */
+    public function testNonHmacRequestsAreIgnored()
+    {
+        $kernel   = $this->getMock(HttpKernelInterface::class);
+        $response = $this->getMock(Response::class);
+
+        $request  = new Request();
+        $event    = new FilterResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        $listener = new HmacResponseListener();
+
+        $listener->onKernelResponse($event);
+
+        $this->assertSame($response, $event->getResponse());
+    }
+
+    /**
+     * Ensures the response listener signs responses correctly.
+     */
+    public function testHmacResponsesAreSigned()
+    {
+        $kernel = $this->getMock(HttpKernelInterface::class);
+
+        $authId     = 'efdde334-fe7b-11e4-a322-1697f925ec7b';
+        $authSecret = 'W5PeGMxSItNerkNFqQMfYiJvH14WzVJMy54CPoTAYoI=';
+        $timestamp  = 1432075982;
+        $authHeader = 'acquia-http-hmac realm="Pipet%20service",id="efdde334-fe7b-11e4-a322-1697f925ec7b",nonce="d1954337-5319-4821-8427-115542e08d10",version="2.0",headers="",signature="Ficfxef2w69S/HoCM8THKWiN/gu2TMMz1skYBc5KPjA="';
+        $signature  = 'LusIUHmqt9NOALrQ4N4MtXZEFE03MjcDjziK+vVqhvQ=';
+
+        $request = Request::create('http://example.com');
+        $request->headers->set('X-Authorization-Timestamp', $timestamp);
+        $request->headers->set('Authorization', $authHeader);
+        $request->attributes->set('hmac.key', new Key($authId, $authSecret));
+
+        $response = new Response();
+        $event    = new FilterResponseEvent($kernel, $request, HttpKernelInterface::MASTER_REQUEST, $response);
+        $listener = new HmacResponseListener();
+
+        $listener->onKernelResponse($event);
+
+        $signedResponse = $event->getResponse();
+
+        $this->assertTrue($signedResponse->headers->has('X-Server-Authorization-HMAC-SHA256'));
+        $this->assertEquals($signature, $signedResponse->headers->get('X-Server-Authorization-HMAC-SHA256'));
+    }
+}

--- a/test/Symfony/HmacSecurityProviderTest.php
+++ b/test/Symfony/HmacSecurityProviderTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Acquia\Hmac\Test\Symfony;
+
+use Acquia\Hmac\KeyLoaderInterface;
+use Acquia\Hmac\Symfony\HmacAuthenticationEntryPoint;
+use Acquia\Hmac\Symfony\HmacAuthenticationListener;
+use Acquia\Hmac\Symfony\HmacAuthenticationProvider;
+use Acquia\Hmac\Symfony\HmacResponseListener;
+use Acquia\Hmac\Symfony\HmacSecurityProvider;
+use Silex\Application;
+use Silex\Provider\SecurityServiceProvider;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Tests the Silex service provider that adds HTTP HMAC as a firewall option.
+ */
+class HmacSecurityProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Ensures the service provider only loads if SecurityServiceProvider is present.
+     *
+     * @expectedException \LogicException
+     * @expectedExceptionMessage You must register the SecurityServiceProvider to use the HmacServiceProvider.
+     */
+    public function testBootFailureWithoutSecurityServiceProvider()
+    {
+        $keyLoader = $this->getMock(KeyLoaderInterface::class);
+
+        $app = new Application();
+        $app->register(new HmacSecurityProvider($keyLoader));
+        $app->boot();
+    }
+
+    /**
+     * Ensures the service provider registers the response listener with the global dispatcher.
+     */
+    public function testResponseListenerIsRegisteredWithDispatcher()
+    {
+        $keyLoader = $this->getMock(KeyLoaderInterface::class);
+
+        $app = new Application();
+        $app->register(new SecurityServiceProvider());
+        $app->register(new HmacSecurityProvider($keyLoader));
+
+        $app['security.firewalls'] = [
+            'http-auth' => [
+                'pattern' => '^.*$',
+                'hmac' => true,
+            ],
+        ];
+
+        $app->boot();
+
+        $this->assertTrue($app['dispatcher']->hasListeners(KernelEvents::RESPONSE));
+    }
+
+    /**
+     * Ensures the service provider registers the correct services.
+     */
+    public function testRegisteredServices()
+    {
+        $firewall = 'http-auth';
+        $authenticationListenerServices = [
+            'security.authentication_provider.' . $firewall . '.hmac',
+            'security.authentication_listener.' . $firewall . '.hmac',
+            'security.entry_point.' . $firewall . '.hmac',
+            'pre_auth',
+        ];
+
+        $keyLoader = $this->getMock(KeyLoaderInterface::class);
+
+        $app = new Application();
+        $app->register(new SecurityServiceProvider());
+        $app->register(new HmacSecurityProvider($keyLoader));
+
+        $app['security.firewalls'] = [
+            $firewall => [
+                'pattern' => '^.*$',
+                'hmac' => true,
+            ],
+        ];
+
+        $app->boot();
+
+        $this->assertArrayHasKey('security.authentication_listener.factory.hmac', $app);
+        $this->assertArrayHasKey('security.hmac.response_listener', $app);
+        $this->assertArrayHasKey('security.authentication_provider.hmac._proto', $app);
+        $this->assertArrayHasKey('security.authentication_listener.hmac._proto', $app);
+        $this->assertArrayHasKey('security.entry_point.hmac._proto', $app);
+        $this->assertInstanceOf(HmacResponseListener::class, $app['security.hmac.response_listener']);
+
+        $factoryResponse = $app['security.authentication_listener.factory.hmac']($firewall, []);
+
+        $this->assertEquals($authenticationListenerServices, $factoryResponse);
+
+        $this->assertArrayHasKey('security.authentication_provider.' . $firewall . '.hmac', $app);
+        $this->assertInstanceOf(HmacAuthenticationProvider::class, $app['security.authentication_provider.' . $firewall . '.hmac']);
+
+        $this->assertArrayHasKey('security.authentication_listener.' . $firewall . '.hmac', $app);
+        $this->assertInstanceOf(HmacAuthenticationListener::class, $app['security.authentication_listener.' . $firewall . '.hmac']);
+
+        $this->assertArrayHasKey('security.entry_point.' . $firewall . '.hmac', $app);
+        $this->assertInstanceOf(HmacAuthenticationEntryPoint::class, $app['security.entry_point.' . $firewall . '.hmac']);
+    }
+}

--- a/test/Symfony/HmacTokenTest.php
+++ b/test/Symfony/HmacTokenTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Acquia\Hmac\Test\Symfony;
+
+use Acquia\Hmac\KeyInterface;
+use Acquia\Hmac\Symfony\HmacToken;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Tests the Symfony authentication token.
+ */
+class HmacTokenTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Ensures the getters work as expected.
+     */
+    public function testGetters()
+    {
+        $request = $this->getMock(Request::class);
+        $key = $this->getMock(KeyInterface::class);
+
+        $token = new HmacToken($request, $key);
+
+        $this->assertEquals($request, $token->getRequest());
+        $this->assertEquals($key, $token->getCredentials());
+    }
+}


### PR DESCRIPTION
This adds full Silex and Symfony integration via Symfony's Security component, allowing Silex/Symfony projects to utilize the security firewall to authenticate using HTTP HMAC.

The implementation is complete, but I still need to add a few more tests. One potential avenue for expansion after this PR is integrating into Symfony's authorization mechanisms, tying keys to roles/permissions.