### PR TITLE
add request and response objects to exceptions

### DIFF
--- a/src/AuthorizationHeader.php
+++ b/src/AuthorizationHeader.php
@@ -46,7 +46,7 @@ class AuthorizationHeader implements AuthorizationHeaderInterface
     public static function createFromRequest(RequestInterface $request)
     {
         if (!$request->hasHeader('Authorization')) {
-            throw new MalformedRequestException('Authorization header is required.');
+            throw new MalformedRequestException('Authorization header is required.', $request);
         }
 
         $header = $request->getHeaderLine('Authorization');
@@ -59,7 +59,10 @@ class AuthorizationHeader implements AuthorizationHeaderInterface
         $headers_match = preg_match('/.*headers="(.*?)"/', $header, $headers_matches);
 
         if (!$id_match || !$realm_match || !$nonce_match || !$version_match || !$signature_match) {
-            throw new MalformedRequestException('Authorization header requires a realm, id, version, nonce and a signature.');
+            throw new MalformedRequestException(
+                'Authorization header requires a realm, id, version, nonce and a signature.',
+                $request
+            );
         }
 
         $customHeaders = !empty($headers_matches[1]) ? explode('%3B', $headers_matches[1]) : [];

--- a/src/AuthorizationHeader.php
+++ b/src/AuthorizationHeader.php
@@ -46,7 +46,7 @@ class AuthorizationHeader implements AuthorizationHeaderInterface
     public static function createFromRequest(RequestInterface $request)
     {
         if (!$request->hasHeader('Authorization')) {
-            throw new MalformedRequestException('Authorization header is required.', $request);
+            throw new MalformedRequestException('Authorization header is required.', null, 0, $request);
         }
 
         $header = $request->getHeaderLine('Authorization');
@@ -61,6 +61,8 @@ class AuthorizationHeader implements AuthorizationHeaderInterface
         if (!$id_match || !$realm_match || !$nonce_match || !$version_match || !$signature_match) {
             throw new MalformedRequestException(
                 'Authorization header requires a realm, id, version, nonce and a signature.',
+                null,
+                0,
                 $request
             );
         }

--- a/src/AuthorizationHeaderBuilder.php
+++ b/src/AuthorizationHeaderBuilder.php
@@ -181,13 +181,22 @@ class AuthorizationHeaderBuilder
         if (empty($this->realm) || empty($this->id) || empty($this->nonce) || empty($this->version)) {
             throw new MalformedRequestException(
                 'One or more required authorization header fields (ID, nonce, realm, version) are missing.',
+                null,
+                0,
                 $this->request
             );
         }
 
         $signature = !empty($this->signature) ? $this->signature : $this->generateSignature();
 
-        return new AuthorizationHeader($this->realm, $this->id, $this->nonce, $this->version, $this->headers, $signature);
+        return new AuthorizationHeader(
+            $this->realm,
+            $this->id,
+            $this->nonce,
+            $this->version,
+            $this->headers,
+            $signature
+        );
     }
 
     /**
@@ -235,6 +244,8 @@ class AuthorizationHeaderBuilder
         if (!$this->request->hasHeader('X-Authorization-Timestamp')) {
             throw new MalformedRequestException(
                 'X-Authorization-Timestamp header missing from request.',
+                null,
+                0,
                 $this->request
             );
         }

--- a/src/AuthorizationHeaderBuilder.php
+++ b/src/AuthorizationHeaderBuilder.php
@@ -179,7 +179,10 @@ class AuthorizationHeaderBuilder
     public function getAuthorizationHeader()
     {
         if (empty($this->realm) || empty($this->id) || empty($this->nonce) || empty($this->version)) {
-            throw new MalformedRequestException('One or more required authorization header fields (ID, nonce, realm, version) are missing.');
+            throw new MalformedRequestException(
+                'One or more required authorization header fields (ID, nonce, realm, version) are missing.',
+                $this->request
+            );
         }
 
         $signature = !empty($this->signature) ? $this->signature : $this->generateSignature();
@@ -230,7 +233,10 @@ class AuthorizationHeaderBuilder
     protected function generateSignature()
     {
         if (!$this->request->hasHeader('X-Authorization-Timestamp')) {
-            throw new MalformedRequestException('X-Authorization-Timestamp header missing from request.');
+            throw new MalformedRequestException(
+                'X-Authorization-Timestamp header missing from request.',
+                $this->request
+            );
         }
 
         $parts = [

--- a/src/Exception/MalformedRequestException.php
+++ b/src/Exception/MalformedRequestException.php
@@ -20,21 +20,21 @@ class MalformedRequestException extends InvalidRequestException
      *
      * @param string $message
      *   The exception message.
-     * @param \Psr\Http\Message\RequestInterface|null $request
-     *   The request.
+     * @param \Exception|null $previous
+     *   The previous exception.
      * @param int $code
      *   The exception code.
-     * @param \Exception|NULL $previous
-     *   The previous exception.
+     * @param \Psr\Http\Message\RequestInterface|null $request
+     *   The request.
      */
-    public function __construct($message = "", RequestInterface $request = null, $code = 0, \Exception $previous = null)
+    public function __construct($message = "", \Exception $previous = null, $code = 0, RequestInterface $request = null)
     {
         parent::__construct($message, $code, $previous);
         $this->request = $request;
     }
 
     /**
-     * Returns the response.
+     * Returns the request.
      *
      * @return RequestInterface
      */
@@ -44,7 +44,7 @@ class MalformedRequestException extends InvalidRequestException
     }
 
     /**
-     * Sets the response.
+     * Sets the request.
      *
      * @param RequestInterface $request
      */

--- a/src/Exception/MalformedRequestException.php
+++ b/src/Exception/MalformedRequestException.php
@@ -2,10 +2,54 @@
 
 namespace Acquia\Hmac\Exception;
 
+use Psr\Http\Message\RequestInterface;
+
 /**
  * Exception thrown when a request cannot be authenticated due to a missing or
  * malformed header.
  */
 class MalformedRequestException extends InvalidRequestException
 {
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+
+    /**
+     * Creates a new MalformedRequestException instance.
+     *
+     * @param string $message
+     *   The exception message.
+     * @param \Psr\Http\Message\RequestInterface|null $request
+     *   The request.
+     * @param int $code
+     *   The exception code.
+     * @param \Exception|NULL $previous
+     *   The previous exception.
+     */
+    public function __construct($message = "", RequestInterface $request = null, $code = 0, \Exception $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $this->request = $request;
+    }
+
+    /**
+     * Returns the response.
+     *
+     * @return RequestInterface
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    /**
+     * Sets the response.
+     *
+     * @param RequestInterface $request
+     */
+    public function setRequest($request)
+    {
+        $this->request = $request;
+    }
 }

--- a/src/Exception/MalformedResponseException.php
+++ b/src/Exception/MalformedResponseException.php
@@ -20,19 +20,18 @@ class MalformedResponseException extends InvalidRequestException
      *
      * @param string $message
      *   The exception message.
-     * @param \Psr\Http\Message\ResponseInterface|null $response
-     *   The request.
+     * @param \Exception|null $previous
+     *   The previous exception.
      * @param int $code
      *   The exception code.
-     * @param \Exception|NULL $previous
-     *   The previous exception.
+     * @param \Psr\Http\Message\ResponseInterface|null $response
+     *   The response.
      */
     public function __construct(
         $message = "",
-        ResponseInterface
-        $response = null,
+        \Exception $previous = null,
         $code = 0,
-        \Exception $previous = null
+        ResponseInterface $response = null
     ) {
         parent::__construct($message, $code, $previous);
         $this->response = $response;

--- a/src/Exception/MalformedResponseException.php
+++ b/src/Exception/MalformedResponseException.php
@@ -2,10 +2,59 @@
 
 namespace Acquia\Hmac\Exception;
 
+use Psr\Http\Message\ResponseInterface;
+
 /**
  * Exception thrown when a response cannot be authenticated due to a missing or
  * malformed header.
  */
 class MalformedResponseException extends InvalidRequestException
 {
+    /**
+     * @var ResponseInterface
+     */
+    private $response;
+
+    /**
+     * Creates a new MalformedResponseException instance.
+     *
+     * @param string $message
+     *   The exception message.
+     * @param \Psr\Http\Message\ResponseInterface|null $response
+     *   The request.
+     * @param int $code
+     *   The exception code.
+     * @param \Exception|NULL $previous
+     *   The previous exception.
+     */
+    public function __construct(
+        $message = "",
+        ResponseInterface
+        $response = null,
+        $code = 0,
+        \Exception $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+        $this->response = $response;
+    }
+
+    /**
+     * Returns the response.
+     *
+     * @return ResponseInterface
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * Sets the response.
+     *
+     * @param ResponseInterface $response
+     */
+    public function setResponse($response)
+    {
+        $this->response = $response;
+    }
 }

--- a/src/Guzzle/HmacAuthMiddleware.php
+++ b/src/Guzzle/HmacAuthMiddleware.php
@@ -61,6 +61,8 @@ class HmacAuthMiddleware
                 if (!$authenticator->isAuthentic($response)) {
                     throw new MalformedResponseException(
                         'Could not verify the authenticity of the response.',
+                        null,
+                        0,
                         $response
                     );
                 }

--- a/src/Guzzle/HmacAuthMiddleware.php
+++ b/src/Guzzle/HmacAuthMiddleware.php
@@ -59,7 +59,10 @@ class HmacAuthMiddleware
                 $authenticator = new ResponseAuthenticator($request, $this->key);
 
                 if (!$authenticator->isAuthentic($response)) {
-                    throw new MalformedResponseException('Could not verify the authenticity of the response.');
+                    throw new MalformedResponseException(
+                        'Could not verify the authenticity of the response.',
+                        $response
+                    );
                 }
 
                 return $response;

--- a/src/RequestAuthenticator.php
+++ b/src/RequestAuthenticator.php
@@ -100,7 +100,7 @@ class RequestAuthenticator implements RequestAuthenticatorInterface
     protected function compareTimestamp(RequestInterface $request, $expiry)
     {
         if (!$request->hasHeader('X-Authorization-Timestamp')) {
-            throw new MalformedRequestException('Request is missing X-Authorization-Timestamp.', $request);
+            throw new MalformedRequestException('Request is missing X-Authorization-Timestamp.', null, 0, $request);
         }
 
         $timestamp = (int) $request->getHeaderLine('X-Authorization-Timestamp');

--- a/src/RequestAuthenticator.php
+++ b/src/RequestAuthenticator.php
@@ -100,7 +100,7 @@ class RequestAuthenticator implements RequestAuthenticatorInterface
     protected function compareTimestamp(RequestInterface $request, $expiry)
     {
         if (!$request->hasHeader('X-Authorization-Timestamp')) {
-            throw new MalformedRequestException('Request is missing X-Authorization-Timestamp.');
+            throw new MalformedRequestException('Request is missing X-Authorization-Timestamp.', $request);
         }
 
         $timestamp = (int) $request->getHeaderLine('X-Authorization-Timestamp');

--- a/src/ResponseAuthenticator.php
+++ b/src/ResponseAuthenticator.php
@@ -45,12 +45,16 @@ class ResponseAuthenticator
         if (!$response->hasHeader('X-Server-Authorization-HMAC-SHA256')) {
             throw new MalformedResponseException(
                 'Response is missing required X-Server-Authorization-HMAC-SHA256 header.',
+                null,
+                0,
                 $response
             );
         }
 
         $responseSigner = new ResponseSigner($this->key, $this->request);
-        $compareResponse = $responseSigner->signResponse($response->withoutHeader('X-Server-Authorization-HMAC-SHA256'));
+        $compareResponse = $responseSigner->signResponse(
+            $response->withoutHeader('X-Server-Authorization-HMAC-SHA256')
+        );
 
         $responseSignature = $response->getHeaderLine('X-Server-Authorization-HMAC-SHA256');
         $compareSignature =  $compareResponse->getHeaderLine('X-Server-Authorization-HMAC-SHA256');

--- a/src/ResponseAuthenticator.php
+++ b/src/ResponseAuthenticator.php
@@ -43,7 +43,10 @@ class ResponseAuthenticator
     public function isAuthentic(ResponseInterface $response)
     {
         if (!$response->hasHeader('X-Server-Authorization-HMAC-SHA256')) {
-            throw new MalformedResponseException('Response is missing required X-Server-Authorization-HMAC-SHA256 header.');
+            throw new MalformedResponseException(
+                'Response is missing required X-Server-Authorization-HMAC-SHA256 header.',
+                $response
+            );
         }
 
         $responseSigner = new ResponseSigner($this->key, $this->request);

--- a/test/AuthorizationHeaderTest.php
+++ b/test/AuthorizationHeaderTest.php
@@ -4,6 +4,7 @@ namespace Acquia\Hmac\Test;
 
 use Acquia\Hmac\AuthorizationHeader;
 use Acquia\Hmac\AuthorizationHeaderBuilder;
+use Acquia\Hmac\Exception\MalformedRequestException;
 use Acquia\Hmac\Key;
 use GuzzleHttp\Psr7\Request;
 
@@ -23,7 +24,9 @@ class AuthorizationHeaderTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        // @codingStandardsIgnoreStart
         $this->header = 'acquia-http-hmac headers="X-Custom-Signer1;X-Custom-Signer2",id="e7fe97fa-a0c8-4a42-ab8e-2c26d52df059",nonce="a9938d07-d9f0-480c-b007-f1e956bcd027",realm="CIStore",signature="0duvqeMauat7pTULg3EgcSmBjrorrcRkGKxRDtZEa1c=",version="2.0"';
+        // @codingStandardsIgnoreEnd
     }
 
     /**
@@ -60,7 +63,12 @@ class AuthorizationHeaderTest extends \PHPUnit_Framework_TestCase
 
         $authHeader = AuthorizationHeader::createFromRequest($request);
 
-        $this->assertEquals((string) $authHeader, 'acquia-http-hmac realm="CIStore",id="e7fe97fa-a0c8-4a42-ab8e-2c26d52df059",nonce="a9938d07-d9f0-480c-b007-f1e956bcd027",version="2.0",headers="X-Custom-Signer1;X-Custom-Signer2",signature="0duvqeMauat7pTULg3EgcSmBjrorrcRkGKxRDtZEa1c="');
+        $this->assertEquals(
+            (string) $authHeader,
+            // @codingStandardsIgnoreStart
+            'acquia-http-hmac realm="CIStore",id="e7fe97fa-a0c8-4a42-ab8e-2c26d52df059",nonce="a9938d07-d9f0-480c-b007-f1e956bcd027",version="2.0",headers="X-Custom-Signer1;X-Custom-Signer2",signature="0duvqeMauat7pTULg3EgcSmBjrorrcRkGKxRDtZEa1c="'
+            // @codingStandardsIgnoreEnd
+        );
     }
 
     /**
@@ -104,34 +112,54 @@ class AuthorizationHeaderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Ensures an exception is thrown if a request does not have an Authorization header.
-     *
-     * @expectedException \Acquia\Hmac\Exception\MalformedRequestException
      */
     public function testCreateFromRequestNoAuthorizationHeader()
     {
+        $this->setExpectedException(
+            '\Acquia\Hmac\Exception\MalformedRequestException',
+            'Authorization header is required.'
+        );
+
         $request = new Request('GET', 'http://example.com');
 
-        AuthorizationHeader::createFromRequest($request);
+        try {
+            AuthorizationHeader::createFromRequest($request);
+        } catch (MalformedRequestException $e) {
+            $this->assertSame($request, $e->getRequest());
+            throw $e;
+        }
     }
 
     /**
      * Ensures an exception is thrown when a required field is missing.
      *
+     * @param $field
+     *   The authorization header field.
+     *
      * @dataProvider requiredFieldsProvider
-     * @expectedException \Acquia\Hmac\Exception\MalformedRequestException
      */
     public function testParseAuthorizationHeaderRequiredFields($field)
     {
+        $this->setExpectedException(
+            '\Acquia\Hmac\Exception\MalformedRequestException',
+            'Authorization header requires a realm, id, version, nonce and a signature.'
+        );
+
         $headers = [
             'Authorization' => preg_replace('/' . $field . '=/', '', $this->header),
         ];
         $request = new Request('GET', 'http://example.com', $headers);
 
-        AuthorizationHeader::createFromRequest($request);
+        try {
+            AuthorizationHeader::createFromRequest($request);
+        } catch (MalformedRequestException $e) {
+            $this->assertSame($request, $e->getRequest());
+            throw $e;
+        }
     }
 
     /**
-     * Provides a list of required authorization haeder fields.
+     * Provides a list of required authorization header fields.
      */
     public function requiredFieldsProvider()
     {
@@ -145,9 +173,15 @@ class AuthorizationHeaderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Acquia\Hmac\Exception\MalformedRequestException
+     * Ensures an exception is thrown when a required field is missing.
      */
-    public function testAuthorizationHeaderBuilderRequiresFields() {
+    public function testAuthorizationHeaderBuilderRequiresFields()
+    {
+        $this->setExpectedException(
+            '\Acquia\Hmac\Exception\MalformedRequestException',
+            'One or more required authorization header fields (ID, nonce, realm, version) are missing.'
+        );
+
         $key = new Key('e7fe97fa-a0c8-4a42-ab8e-2c26d52df059', 'bXlzZWNyZXRzZWNyZXR0aGluZ3Rva2VlcA==');
         $headers = [
             'X-Authorization-Timestamp' => '1432075982',
@@ -157,13 +191,25 @@ class AuthorizationHeaderTest extends \PHPUnit_Framework_TestCase
         $builder = new AuthorizationHeaderBuilder($request, $key);
         $builder->setNonce('a9938d07-d9f0-480c-b007-f1e956bcd027');
         $builder->setVersion('2.0');
-        $header = $builder->getAuthorizationHeader();
+
+        try {
+            $builder->getAuthorizationHeader();
+        } catch (MalformedRequestException $e) {
+            $this->assertSame($request, $e->getRequest());
+            throw $e;
+        }
     }
 
     /**
-     * @expectedException \Acquia\Hmac\Exception\MalformedRequestException
+     * Ensures an exception is thrown when the required X-Authorization-Timestamp field is missing.
      */
-    public function testAuthorizationHeaderBuilderRequiresTimestamp() {
+    public function testAuthorizationHeaderBuilderRequiresTimestamp()
+    {
+        $this->setExpectedException(
+            '\Acquia\Hmac\Exception\MalformedRequestException',
+            'X-Authorization-Timestamp header missing from request.'
+        );
+
         $key = new Key('e7fe97fa-a0c8-4a42-ab8e-2c26d52df059', 'bXlzZWNyZXRzZWNyZXR0aGluZ3Rva2VlcA==');
         $headers = [
             'Content-Type' => 'application/json',
@@ -173,10 +219,17 @@ class AuthorizationHeaderTest extends \PHPUnit_Framework_TestCase
         $builder->setId($key->getId());
         $builder->setNonce('a9938d07-d9f0-480c-b007-f1e956bcd027');
         $builder->setVersion('2.0');
-        $header = $builder->getAuthorizationHeader();
+
+        try {
+            $builder->getAuthorizationHeader();
+        } catch (MalformedRequestException $e) {
+            $this->assertSame($request, $e->getRequest());
+            throw $e;
+        }
     }
 
-    public function testAuthorizationHeaderBuilder() {
+    public function testAuthorizationHeaderBuilder()
+    {
         $key = new Key('e7fe97fa-a0c8-4a42-ab8e-2c26d52df059', 'bXlzZWNyZXRzZWNyZXR0aGluZ3Rva2VlcA==');
         $headers = [
             'X-Authorization-Timestamp' => '1432075982',

--- a/test/AuthorizationHeaderTest.php
+++ b/test/AuthorizationHeaderTest.php
@@ -112,14 +112,12 @@ class AuthorizationHeaderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Ensures an exception is thrown if a request does not have an Authorization header.
+     *
+     * @expectedException \Acquia\Hmac\Exception\MalformedRequestException
+     * @expectedExceptionMessage Authorization header is required.
      */
     public function testCreateFromRequestNoAuthorizationHeader()
     {
-        $this->setExpectedException(
-            '\Acquia\Hmac\Exception\MalformedRequestException',
-            'Authorization header is required.'
-        );
-
         $request = new Request('GET', 'http://example.com');
 
         try {
@@ -137,14 +135,12 @@ class AuthorizationHeaderTest extends \PHPUnit_Framework_TestCase
      *   The authorization header field.
      *
      * @dataProvider requiredFieldsProvider
+     *
+     * @expectedException \Acquia\Hmac\Exception\MalformedRequestException
+     * @expectedExceptionMessage Authorization header requires a realm, id, version, nonce and a signature.
      */
     public function testParseAuthorizationHeaderRequiredFields($field)
     {
-        $this->setExpectedException(
-            '\Acquia\Hmac\Exception\MalformedRequestException',
-            'Authorization header requires a realm, id, version, nonce and a signature.'
-        );
-
         $headers = [
             'Authorization' => preg_replace('/' . $field . '=/', '', $this->header),
         ];
@@ -174,14 +170,12 @@ class AuthorizationHeaderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Ensures an exception is thrown when a required field is missing.
+     *
+     * @expectedException \Acquia\Hmac\Exception\MalformedRequestException
+     * @expectedExceptionMessage One or more required authorization header fields (ID, nonce, realm, version) are missing.
      */
     public function testAuthorizationHeaderBuilderRequiresFields()
     {
-        $this->setExpectedException(
-            '\Acquia\Hmac\Exception\MalformedRequestException',
-            'One or more required authorization header fields (ID, nonce, realm, version) are missing.'
-        );
-
         $key = new Key('e7fe97fa-a0c8-4a42-ab8e-2c26d52df059', 'bXlzZWNyZXRzZWNyZXR0aGluZ3Rva2VlcA==');
         $headers = [
             'X-Authorization-Timestamp' => '1432075982',
@@ -202,14 +196,12 @@ class AuthorizationHeaderTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Ensures an exception is thrown when the required X-Authorization-Timestamp field is missing.
+     *
+     * @expectedException \Acquia\Hmac\Exception\MalformedRequestException
+     * @expectedExceptionMessage X-Authorization-Timestamp header missing from request.
      */
     public function testAuthorizationHeaderBuilderRequiresTimestamp()
     {
-        $this->setExpectedException(
-            '\Acquia\Hmac\Exception\MalformedRequestException',
-            'X-Authorization-Timestamp header missing from request.'
-        );
-
         $key = new Key('e7fe97fa-a0c8-4a42-ab8e-2c26d52df059', 'bXlzZWNyZXRzZWNyZXR0aGluZ3Rva2VlcA==');
         $headers = [
             'Content-Type' => 'application/json',

--- a/test/GuzzleAuthMiddlewareTest.php
+++ b/test/GuzzleAuthMiddlewareTest.php
@@ -96,14 +96,12 @@ class GuzzleAuthMiddlewareTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Ensures the middleware throws an exception if the response is missing the right header.
+     *
+     * @expectedException \Acquia\Hmac\Exception\MalformedResponseException
+     * @expectedExceptionMessage Response is missing required X-Server-Authorization-HMAC-SHA256 header.
      */
     public function testMissingRequiredResponseHeader()
     {
-        $this->setExpectedException(
-            '\Acquia\Hmac\Exception\MalformedResponseException',
-            'Response is missing required X-Server-Authorization-HMAC-SHA256 header.'
-        );
-
         $stack = new HandlerStack();
         $stack->setHandler(new MockHandler([new Response(200)]));
         $stack->push(new HmacAuthMiddleware($this->authKey));

--- a/test/RequestAuthenticatorTest.php
+++ b/test/RequestAuthenticatorTest.php
@@ -193,14 +193,12 @@ class RequestAuthenticatorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Ensures an exception is thrown if the request is missing the X-Authorization-Timestamp header.
+     *
+     * @expectedException \Acquia\Hmac\Exception\MalformedRequestException
+     * @expectedExceptionMessage Request is missing X-Authorization-Timestamp.
      */
     public function testMissingAuthenticationTimestampHeader()
     {
-        $this->setExpectedException(
-            '\Acquia\Hmac\Exception\MalformedRequestException',
-            'Request is missing X-Authorization-Timestamp.'
-        );
-
         $headers = [
             'Content-Type' => 'text/plain',
             'Authorization' => 'acquia-http-hmac realm="Pipet service",'

--- a/test/ResponseAuthenticatorTest.php
+++ b/test/ResponseAuthenticatorTest.php
@@ -4,6 +4,7 @@ namespace Acquia\Hmac\Test;
 
 use Acquia\Hmac\AuthorizationHeaderBuilder;
 use Acquia\Hmac\Digest\Digest;
+use Acquia\Hmac\Exception\MalformedResponseException;
 use Acquia\Hmac\Key;
 use Acquia\Hmac\ResponseAuthenticator;
 use Acquia\Hmac\Test\Mocks\MockRequestSigner;
@@ -69,16 +70,24 @@ class ResponseAuthenticatorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Ensures an exception is thrown if response is missing a X-Server-Authorization-HMAC-SHA256 header.
-     *
-     * @expectedException \Acquia\Hmac\Exception\MalformedResponseException
      */
     public function testMissingServerAuthorizationHeader()
     {
+        $this->setExpectedException(
+            '\Acquia\Hmac\Exception\MalformedResponseException',
+            'Response is missing required X-Server-Authorization-HMAC-SHA256 header.'
+        );
+
         $request = new Request('GET', 'http://example.com');
         $response = new Response();
 
         $authenticator = new ResponseAuthenticator($request, $this->authKey);
 
-        $authenticator->isAuthentic($response);
+        try {
+            $authenticator->isAuthentic($response);
+        } catch (MalformedResponseException $e) {
+            $this->assertSame($response, $e->getResponse());
+            throw $e;
+        }
     }
 }

--- a/test/ResponseAuthenticatorTest.php
+++ b/test/ResponseAuthenticatorTest.php
@@ -70,14 +70,12 @@ class ResponseAuthenticatorTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Ensures an exception is thrown if response is missing a X-Server-Authorization-HMAC-SHA256 header.
+     *
+     * @expectedException \Acquia\Hmac\Exception\MalformedResponseException
+     * @expectedExceptionMessage Response is missing required X-Server-Authorization-HMAC-SHA256 header.
      */
     public function testMissingServerAuthorizationHeader()
     {
-        $this->setExpectedException(
-            '\Acquia\Hmac\Exception\MalformedResponseException',
-            'Response is missing required X-Server-Authorization-HMAC-SHA256 header.'
-        );
-
         $request = new Request('GET', 'http://example.com');
         $response = new Response();
 


### PR DESCRIPTION
This PR adds an ability to the `MalformedRequestException` and `MalformedResponseException` to contain the respective object that caused the exception. This helps users to handle these exceptions in a more refined way, i.e. by the response code of the non-authentic response.

I haven't added any tests yet, please do a quick review first.
Please note, that this PR introduces API change in `MalformedRequestException` and `MalformedResponseException` as I added a new parameter to the constructor. If we don't want this API change, I can rework this part to use the setter methods when needed.
