### PR TITLE
Fix timing attack by using hash_equals() to compare hashes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
     "require": {
         "php": ">=5.5.0",
-        "psr/http-message": "~1.0.0"
+        "psr/http-message": "~1.0.0",
+        "sarciszewski/php-future": "~0.4.2"
     },
     "suggest": {
         "guzzlehttp/guzzle": "~6.0",

--- a/src/RequestAuthenticator.php
+++ b/src/RequestAuthenticator.php
@@ -71,7 +71,7 @@ class RequestAuthenticator implements RequestAuthenticatorInterface
         $compareSignature = $compareAuthHeader->getSignature();
 
 
-        if ($signature !== $compareSignature) {
+        if (!hash_equals($signature, $compareSignature)) {
             throw new InvalidSignatureException('Signature not valid');
         }
 

--- a/src/RequestAuthenticator.php
+++ b/src/RequestAuthenticator.php
@@ -71,7 +71,7 @@ class RequestAuthenticator implements RequestAuthenticatorInterface
         $compareSignature = $compareAuthHeader->getSignature();
 
 
-        if (!hash_equals($signature, $compareSignature)) {
+        if (!hash_equals($compareSignature, $signature)) {
             throw new InvalidSignatureException('Signature not valid');
         }
 

--- a/src/ResponseAuthenticator.php
+++ b/src/ResponseAuthenticator.php
@@ -59,6 +59,6 @@ class ResponseAuthenticator
         $responseSignature = $response->getHeaderLine('X-Server-Authorization-HMAC-SHA256');
         $compareSignature =  $compareResponse->getHeaderLine('X-Server-Authorization-HMAC-SHA256');
 
-        return hash_equals($responseSignature, $compareSignature);
+        return hash_equals($compareSignature, $responseSignature);
     }
 }

--- a/src/ResponseAuthenticator.php
+++ b/src/ResponseAuthenticator.php
@@ -59,6 +59,6 @@ class ResponseAuthenticator
         $responseSignature = $response->getHeaderLine('X-Server-Authorization-HMAC-SHA256');
         $compareSignature =  $compareResponse->getHeaderLine('X-Server-Authorization-HMAC-SHA256');
 
-        return $responseSignature === $compareSignature;
+        return hash_equals($responseSignature, $compareSignature);
     }
 }


### PR DESCRIPTION
Since we're currently still supporting PHP 5.5, we need to use a polyfill.

Resolves #20.
