### PR TITLE
Make X-Authorization-Timestamp a string

### DIFF
--- a/src/RequestSigner.php
+++ b/src/RequestSigner.php
@@ -71,7 +71,7 @@ class RequestSigner implements RequestSignerInterface
         $date = $date ?: new \DateTime('now', new \DateTimeZone('UTC'));
 
         /** @var RequestInterface $request */
-        $request = $request->withHeader('X-Authorization-Timestamp', $date->getTimestamp());
+        $request = $request->withHeader('X-Authorization-Timestamp', (string) $date->getTimestamp());
 
         return $request;
     }


### PR DESCRIPTION
zend-diactoros requires that header values to be true when passed to is_string