### PR TITLE
README.md: Corrected a mistake in the symfony firewall section

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ PHPUnit testing a controller behind HMAC HTTP authentification in Symfony:
 
 services:
     test.client.hmac:
-        class: Acquia\Hmac\Symfony\Tests\HmacClient
+        class: Acquia\Hmac\Test\Mocks\Symfony\HmacClientlient
         arguments: ['@kernel', '%test.client.parameters%', '@test.client.history', '@test.client.cookiejar']
 
 ```

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ class AppBundle extends Bundle
 }
 ```
 
-PHPUnit testing a controller behind HMAC HTTP authentification in Symfony:
+PHPUnit testing a controller using HMAC HTTP authentication in Symfony:
 
 1. Add the service declaration:
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,12 @@ services:
         arguments:
          - '@hmac.keyloader'
         public: false
-
+        
+    hmac.response.signer:
+        class: Acquia\Hmac\Symfony\HmacResponseListener
+        tags:
+          - { name: kernel.event_listener, event: kernel.response, method: onKernelResponse }
+          
     hmac.entry-point:
         class: Acquia\Hmac\Symfony\HmacAuthenticationEntryPoint
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ security:
         hmac_auth:
             pattern:   ^/api/
             stateless: true
-            wsse:      true
+            hmac_auth: true
 ```
 
 ```php

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ $options = [
 ];
 
 // A key consists of your UUID and a MIME base64 encoded shared secret.
-$key = new Key('e7fe97fa-a0c8-4a42-ab8e-2c26d52df059', base64_encode('secret'));
+$key = new Key('e7fe97fa-a0c8-4a42-ab8e-2c26d52df059', 'secret');
 
 // Provide your key, realm and optional signed headers.
 $middleware = new HmacAuthMiddleware($key, 'CIStore', array_keys($options['headers']));

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ In order to use the provided Symfony integration, you will need to include the f
 }
 ```
 
-Sammple implementation:
+Sample implementation:
 
 ```yaml
 # app/config/parameters.yml
@@ -202,6 +202,60 @@ class AppBundle extends Bundle
     }
 }
 ```
+
+PHPUnit testing a controller behind HMAC HTTP authentification in Symfony :
+
+1. Add the service declaration:
+
+
+```yaml
+# app/config/parameters_test.yml
+
+services:
+    test.client.hmac:
+        class: Acquia\Hmac\Symfony\Tests\HmacClient
+        arguments: ['@kernel', '%test.client.parameters%', '@test.client.history', '@test.client.cookiejar']
+
+```
+
+```php
+// src/AppBundle/Tests/HmacTestCase.php
+
+namespace MyApp\Bundle\AppBundle\Tests;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Acquia\Hmac\Key;
+
+class HmacTestCase extends WebTestCase
+{
+    /**
+     * @var Client
+     */
+    private $client;
+
+    protected static function createClient(array $options = array(), array $server = array())
+    {
+        $kernel = static::bootKernel($options);
+
+        $client = $kernel->getContainer()->get('test.client.hmac');
+        $client->setServerParameters($server);
+
+        return $client;
+    }
+
+    protected function setUp()
+    {
+        $this->client = static::createClient();
+
+        //set the key from the consumer
+        $this->client->setKey(new Key("my-key", "my-not-really-secret"));
+
+    }
+```
+
+
 
 ## Contributing and Development
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ $options = [
   ],
 ];
 
-// A key consists of your UUID and a MIME base64 encoded shared secret.
-$key = new Key('e7fe97fa-a0c8-4a42-ab8e-2c26d52df059', 'secret');
+// A key consists of your UUID and a Base64-encoded shared secret.
+ // Note: the API provider may have already encoded the secret. In this case, it should not be re-encoded.
+$key = new Key('e7fe97fa-a0c8-4a42-ab8e-2c26d52df059', base64_encode('secret'));
 
 // Provide your key, realm and optional signed headers.
 $middleware = new HmacAuthMiddleware($key, 'CIStore', array_keys($options['headers']));
@@ -203,10 +204,9 @@ class AppBundle extends Bundle
 }
 ```
 
-PHPUnit testing a controller behind HMAC HTTP authentification in Symfony :
+PHPUnit testing a controller behind HMAC HTTP authentification in Symfony:
 
 1. Add the service declaration:
-
 
 ```yaml
 # app/config/parameters_test.yml
@@ -249,13 +249,9 @@ class HmacTestCase extends WebTestCase
     {
         $this->client = static::createClient();
 
-        //set the key from the consumer
-        $this->client->setKey(new Key("my-key", "my-not-really-secret"));
-
+        $this->client->setKey(new Key('my-key', 'my-not-really-secret'));
     }
 ```
-
-
 
 ## Contributing and Development
 

--- a/src/Symfony/Tests/HmacClient.php
+++ b/src/Symfony/Tests/HmacClient.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Acquia\Hmac\Symfony\Tests;
+
+use Acquia\Hmac\Key;
+use Acquia\Hmac\RequestSigner;
+use Acquia\Hmac\ResponseAuthenticator;
+use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+
+class HmacClient extends Client
+{
+
+    /**
+     * @var Key
+     */
+    protected $key;
+
+    /**
+     * Set Key for HMAC Auth
+     *
+     * @param Key $key
+     * @return Key
+     */
+    public function setKey(Key $key) {
+
+        $this->key = $key;
+
+        return $this;
+
+    }
+
+    /**
+     * Sign the request with HMAC HTTP and verify the response signature
+     *
+     * @param \Symfony\Component\HttpFoundation\Request $request
+     * @return \Symfony\Component\HttpFoundation\Response
+     * @throws \Exception
+     */
+    protected function doRequest($request)
+    {
+
+        if(!$this->key instanceof Key) {
+            throw new \Exception("Key not provided");
+        }
+
+        $psr7Factory = new DiactorosFactory();
+        $httpFoundationFactory = new HttpFoundationFactory();
+
+        //convert the symfony request to PSR7 request
+        $psrRequest = $psr7Factory->createRequest($request);
+
+        //sign the request
+        $hmacSigner = new RequestSigner($this->key);
+        $signedRequest = $hmacSigner->signRequest($psrRequest);
+
+        //convert back the signed PSR7 request to the symfony request
+        $symfonyRequest = $httpFoundationFactory->createRequest($signedRequest);
+
+        //send the request to the kernel and get the response
+        $response = parent::doRequest($symfonyRequest);
+
+        //convert the symfony response to psr7 response
+        $psrResponse = $psr7Factory->createResponse($response);
+
+        //init the authenticator and verify if the psr7 response signature is valid
+        $authenticator = new ResponseAuthenticator($signedRequest, $this->key);
+
+        if(!$authenticator->isAuthentic($psrResponse)) {
+            throw new \Exception("The response cannot be authenticated !");
+        }
+
+        //return the symfony response
+        return $response;
+    }
+
+}

--- a/test/Mocks/Symfony/HmacClient.php
+++ b/test/Mocks/Symfony/HmacClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Acquia\Hmac\Symfony\Tests;
+namespace Acquia\Hmac\Test\Mocks\Symfony;
 
 use Acquia\Hmac\Key;
 use Acquia\Hmac\RequestSigner;

--- a/test/Mocks/Symfony/HmacClient.php
+++ b/test/Mocks/Symfony/HmacClient.php
@@ -49,7 +49,7 @@ class HmacClient extends Client
      */
     protected function doRequest($request)
     {
-        if(!$this->key instanceof Key) {
+        if (!$this->key instanceof Key) {
             throw new \Exception('HTTP HMAC key has not been provided.');
         }
 
@@ -67,7 +67,7 @@ class HmacClient extends Client
 
         $authenticator = new ResponseAuthenticator($signedRequest, $this->key);
 
-        if(!$authenticator->isAuthentic($psrResponse)) {
+        if (!$authenticator->isAuthentic($psrResponse)) {
             throw new \Exception('The response cannot be authenticated.');
         }
 

--- a/test/Mocks/Symfony/HmacClient.php
+++ b/test/Mocks/Symfony/HmacClient.php
@@ -2,40 +2,50 @@
 
 namespace Acquia\Hmac\Test\Mocks\Symfony;
 
-use Acquia\Hmac\Key;
+use Acquia\Hmac\KeyInterface;
 use Acquia\Hmac\RequestSigner;
 use Acquia\Hmac\ResponseAuthenticator;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 
+/**
+ * A mock Symfony client for testing HTTP HMAC request signing and response authentication.
+ */
 class HmacClient extends Client
 {
     /**
-     * @var Key
+     * @var \Acquia\Hmac\KeyInterface $key
+     *   The key to sign requests with.
      */
     protected $key;
 
     /**
      * Set the private key for HTTP HMAC authentication.
      *
-     * @param Key $key
-     * @return Key
+     * @param \Acquia\Hmac\KeyInterface $key
+     *   The key to sign requests with.
+     *
+     * @return static
      */
-    public function setKey(Key $key) {
-
+    public function setKey(KeyInterface $key)
+    {
         $this->key = $key;
 
         return $this;
-
     }
 
     /**
-     * Sign the request with HTTP HMAC and verify the response signature.
+     * Sign the request with HTTP HMAC and authenticate the response signature.
      *
      * @param \Symfony\Component\HttpFoundation\Request $request
-     * @return \Symfony\Component\HttpFoundation\Response
+     *   The Symfony request.
+     *
      * @throws \Exception
+     *   If the key has not been provided, or the respnonse cannot be authenticated.
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
+     *   An authenticated Symfony response.
      */
     protected function doRequest($request)
     {
@@ -50,11 +60,9 @@ class HmacClient extends Client
 
         $hmacSigner = new RequestSigner($this->key);
         $signedRequest = $hmacSigner->signRequest($psrRequest);
-
         $symfonyRequest = $httpFoundationFactory->createRequest($signedRequest);
 
         $response = parent::doRequest($symfonyRequest);
-
         $psrResponse = $psr7Factory->createResponse($response);
 
         $authenticator = new ResponseAuthenticator($signedRequest, $this->key);

--- a/test/Mocks/Symfony/HmacClient.php
+++ b/test/Mocks/Symfony/HmacClient.php
@@ -8,6 +8,7 @@ use Acquia\Hmac\ResponseAuthenticator;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * A mock Symfony client for testing HTTP HMAC request signing and response authentication.
@@ -41,16 +42,13 @@ class HmacClient extends Client
      * @param \Symfony\Component\HttpFoundation\Request $request
      *   The Symfony request.
      *
-     * @throws \Exception
-     *   If the key has not been provided, or the respnonse cannot be authenticated.
-     *
      * @return \Symfony\Component\HttpFoundation\Response
-     *   An authenticated Symfony response.
+     *   An Symfony response indicating the result of making the signed request.
      */
     protected function doRequest($request)
     {
         if (!$this->key instanceof Key) {
-            throw new \Exception('HTTP HMAC key has not been provided.');
+            return new Response('The HTTP HMAC key has not been provided.', 400);
         }
 
         $psr7Factory = new DiactorosFactory();
@@ -68,7 +66,7 @@ class HmacClient extends Client
         $authenticator = new ResponseAuthenticator($signedRequest, $this->key);
 
         if (!$authenticator->isAuthentic($psrResponse)) {
-            throw new \Exception('The response cannot be authenticated.');
+            return new Response('The response cannot be authenticated.', 400);
         }
 
         return $response;


### PR DESCRIPTION
The name of the firewall has been corrected from `wsse` to `hmac_auth`