### PR TITLE
 Fixes Response::getBody->getContents() returns empty string (#34)

### DIFF
--- a/src/ResponseSigner.php
+++ b/src/ResponseSigner.php
@@ -60,6 +60,8 @@ class ResponseSigner
             (string) $response->getBody(),
         ];
 
+        $response->getBody()->rewind();
+
         $message = implode("\n", $parts);
 
         $signature = $this->digest->sign($message, $this->key->getSecret());

--- a/test/ResponseSignerTest.php
+++ b/test/ResponseSignerTest.php
@@ -26,7 +26,8 @@ class ResponseSignerTest extends \PHPUnit_Framework_TestCase
         $realm = 'Pipet service';
         $nonce = 'd1954337-5319-4821-8427-115542e08d10';
         $timestamp = 1432075982;
-        $signature = 'LusIUHmqt9NOALrQ4N4MtXZEFE03MjcDjziK+vVqhvQ=';
+        $signature = 'dAE9Kizn1PCOrc45H/X41RdFMCwpED18k9iJjrHFqUU=';
+        $body = 'Test body string';
 
         $authKey = new Key($authId, $authSecret);
 
@@ -44,12 +45,13 @@ class ResponseSignerTest extends \PHPUnit_Framework_TestCase
         $requestSigner = new MockRequestSigner($authKey, $realm, new Digest(), $authHeader);
         $signedRequest = $requestSigner->signRequest($request);
 
-        $response = new Response();
+        $response = new Response(200, [], $body);
         
         $responseSigner = new ResponseSigner($authKey, $signedRequest);
         $signedResponse = $responseSigner->signResponse($response);
 
         $this->assertTrue($signedResponse->hasHeader('X-Server-Authorization-HMAC-SHA256'));
         $this->assertEquals($signature, $signedResponse->getHeaderLine('X-Server-Authorization-HMAC-SHA256'));
+        $this->assertEquals($body, $response->getBody()->getContents());
     }
 }


### PR DESCRIPTION
In the ResponseSigner::signResponse($response), the stream of the response body wasn't rewound, meaning calling (the same instance of) $response->getBody()->getContents() afterwards when using the middleware would always return an empty string. However, using Response::getBody() as a string through implicit or explicit casting would already work previously, because __toString() always rewinds.

Unit test included, breaks as expected with previous version of signResponse().