### PR TITLE
Use a cryptographically-secure method to generate the nonce

### DIFF
--- a/src/AuthorizationHeaderBuilder.php
+++ b/src/AuthorizationHeaderBuilder.php
@@ -211,7 +211,7 @@ class AuthorizationHeaderBuilder
      */
     public function generateNonce()
     {
-        $data = openssl_random_pseudo_bytes(16);
+        $data = function_exists('random_bytes') ? random_bytes(16) : openssl_random_pseudo_bytes(16);
         $data[6] = chr(ord($data[6]) & 0x0f | 0x40); // set version to 0100
         $data[8] = chr(ord($data[8]) & 0x3f | 0x80); // set bits 6-7 to 10
 

--- a/src/AuthorizationHeaderBuilder.php
+++ b/src/AuthorizationHeaderBuilder.php
@@ -211,7 +211,7 @@ class AuthorizationHeaderBuilder
      */
     public function generateNonce()
     {
-        $data = random_bytes(16);
+        $data = openssl_random_pseudo_bytes(16);
         $data[6] = chr(ord($data[6]) & 0x0f | 0x40); // set version to 0100
         $data[8] = chr(ord($data[8]) & 0x3f | 0x80); // set bits 6-7 to 10
 

--- a/src/AuthorizationHeaderBuilder.php
+++ b/src/AuthorizationHeaderBuilder.php
@@ -204,30 +204,18 @@ class AuthorizationHeaderBuilder
      *
      * The nonce is a v4 UUID.
      *
+     * @see https://stackoverflow.com/a/15875555
+     *
      * @return string
      *   The generated nonce.
      */
     public function generateNonce()
     {
-        return sprintf(
-            '%04x%04x-%04x-%04x-%04x-%04x%04x%04x',
-            // 32 bits for "time_low"
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            // 16 bits for "time_mid"
-            mt_rand(0, 0xffff),
-            // 16 bits for "time_hi_and_version",
-            // four most significant bits holds version number 4
-            mt_rand(0, 0x0fff) | 0x4000,
-            // 16 bits, 8 bits for "clk_seq_hi_res",
-            // 8 bits for "clk_seq_low",
-            // two most significant bits holds zero and one for variant DCE1.1
-            mt_rand(0, 0x3fff) | 0x8000,
-            // 48 bits for "node"
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff),
-            mt_rand(0, 0xffff)
-        );
+        $data = random_bytes(16);
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40); // set version to 0100
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80); // set bits 6-7 to 10
+
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
     }
 
     /**


### PR DESCRIPTION
`mt_rand()` is not cryptographically-secure and there are better ways to generate a UUID. This updates `AuthorizationHeaderBuilder::generateNonce()` to use `openss_random_pseudo_bytes()`, instead.