### PR TITLE
Remove support for PHP 5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ php:
   - 7.1
   - 7.0
   - 5.6
-  - 5.5
 
 before_script:
   - travis_retry composer self-update

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,8 @@
         "issues": "https://github.com/acquia/http-hmac-php/issues"
     },
     "require": {
-        "php": ">=5.5.0",
-        "psr/http-message": "~1.0.0",
-        "sarciszewski/php-future": "~0.4.2"
+        "php": "~5.6 || ~7.0",
+        "psr/http-message": "~1.0.0"
     },
     "suggest": {
         "guzzlehttp/guzzle": "~6.0",


### PR DESCRIPTION
Fixes #22.

A deprecation notice will be added to notes of the next release of the 3.x line (currently scheduled to be 3.4.0).