### PR TITLE
Switch to PHP-CS-Fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@ composer.lock
 
 # Ignore local PHPUnit configuration
 /phpunit.xml
+
+# Ignore PHP-CS-Fixer files
+/.php_cs
+/.php_cs.cache
+/cs_fixer_tmp_*

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @file
+ * PHP-CS-Fixer configuration
+ *
+ */
+
+$finder = PhpCsFixer\Finder::create()
+    ->in([
+        __DIR__ . '/src',
+        __DIR__ . '/test',
+    ]);
+
+$config = PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+        'array_indentation' => true,
+        'array_syntax' => [
+            'syntax' => 'short',
+        ],
+        'concat_space' => [
+            'spacing' => 'one',
+        ],
+        'method_chaining_indentation' => true,
+        'phpdoc_indent' => true,
+        'no_unused_imports' => true,
+        'no_blank_lines_after_class_opening' => true,
+        'no_blank_lines_after_phpdoc' => true,
+        'no_whitespace_before_comma_in_array' => true,
+        'no_whitespace_in_blank_line' => true,
+        'php_unit_namespaced' => true,
+        'psr4' => true,
+        'short_scalar_cast' => true,
+        'trailing_comma_in_multiline_array' => true,
+    ])
+    ->setFinder($finder);
+
+return $config;

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,11 @@ php:
   - 7.0
   - 5.6
 
-before_script:
+before_install:
   - travis_retry composer self-update
+  - phpenv config-rm xdebug.ini
+
+before_script:
   - travis_retry make install
 
 script:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: install clean test coverage update
+.PHONY: install clean test coverage update format
 
 install:
 	composer install --no-interaction
@@ -8,7 +8,7 @@ clean:
 
 test: install
 	./vendor/bin/phpunit
-	./vendor/bin/phpcs --standard=PSR2 --runtime-set ignore_warnings_on_exit 1 src/ test/
+	./vendor/bin/php-cs-fixer fix --dry-run -v
 	./vendor/bin/phpmd  src/,test/ text ./phpmd.xml
 	./vendor/bin/phpcpd src/ test/
 	./vendor/bin/phploc src/
@@ -18,3 +18,6 @@ coverage: install
 
 update:
 	composer update --no-interaction
+
+format: install
+	./vendor/bin/php-cs-fixer fix -v

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpmd/phpmd": "^2.0",
         "phpunit/phpunit": "~5.7",
         "sebastian/phpcpd": "^2.0",
-        "squizlabs/php_codesniffer": "^2.3",
+        "friendsofphp/php-cs-fixer": "^2.11",
         "symfony/psr-http-message-bridge": "^1.0",
         "symfony/security": "^3.0 | ^4.0",
         "symfony/security-bundle": "^3.0 | ^4.0",

--- a/src/AuthorizationHeaderBuilder.php
+++ b/src/AuthorizationHeaderBuilder.php
@@ -128,7 +128,7 @@ class AuthorizationHeaderBuilder
      * Set the spec version.
      *
      * This is optional: if not called, the version will be "2.0".
-    *
+     *
      * @param string $version
      *   The spec version.
      */

--- a/src/Guzzle/HmacAuthMiddleware.php
+++ b/src/Guzzle/HmacAuthMiddleware.php
@@ -6,8 +6,6 @@ use Acquia\Hmac\Exception\MalformedResponseException;
 use Acquia\Hmac\KeyInterface;
 use Acquia\Hmac\RequestSigner;
 use Acquia\Hmac\ResponseAuthenticator;
-use Guzzle\Http\Exception\BadResponseException;
-use GuzzleHttp\Exception\RequestException;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -51,11 +49,9 @@ class HmacAuthMiddleware
     public function __invoke(callable $handler)
     {
         return function ($request, array $options) use ($handler) {
-
             $request = $this->signRequest($request);
 
             $promise = function (ResponseInterface $response) use ($request) {
-
                 if ($response->getStatusCode() != 401) {
                     $authenticator = new ResponseAuthenticator($request, $this->key);
 

--- a/src/RequestAuthenticator.php
+++ b/src/RequestAuthenticator.php
@@ -37,7 +37,6 @@ class RequestAuthenticator implements RequestAuthenticatorInterface
      */
     public function authenticate(RequestInterface $request)
     {
-
         $authHeader = AuthorizationHeader::createFromRequest($request);
         $signature = $authHeader->getSignature();
 

--- a/src/Symfony/HmacFactory.php
+++ b/src/Symfony/HmacFactory.php
@@ -5,7 +5,6 @@ namespace Acquia\Hmac\Symfony;
 use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\SecurityFactoryInterface;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 
 /**
@@ -26,7 +25,7 @@ class HmacFactory implements SecurityFactoryInterface
         $listenerId = 'security.authentication.listener.hmac.' . $id;
         $container->setDefinition($listenerId, new ChildDefinition('hmac.security.authentication.listener'));
 
-        return array($providerId, $listenerId, $defaultEntryPoint);
+        return [$providerId, $listenerId, $defaultEntryPoint];
     }
 
     /**

--- a/test/AcquiaSpecTest.php
+++ b/test/AcquiaSpecTest.php
@@ -5,8 +5,6 @@ namespace Acquia\Hmac\Test;
 use Acquia\Hmac\AuthorizationHeaderBuilder;
 use Acquia\Hmac\Digest\Digest;
 use Acquia\Hmac\Key;
-use Acquia\Hmac\RequestAuthenticator;
-use Acquia\Hmac\RequestSigner;
 use Acquia\Hmac\ResponseSigner;
 use Acquia\Hmac\Test\Mocks\MockKeyLoader;
 use Acquia\Hmac\Test\Mocks\MockRequestAuthenticator;
@@ -90,7 +88,7 @@ class AcquiaSpecTest extends TestCase
 
         // Prove that the authenticator can authenticate the request.
         $keyLoader = new MockKeyLoader([
-                $input['id'] => $input['secret'],
+            $input['id'] => $input['secret'],
         ] + $this->keys);
         $authenticator = new MockRequestAuthenticator($keyLoader, null, $input['timestamp']);
         $compareKey = $authenticator->authenticate($signedRequest);

--- a/test/Base64KeyLoaderTest.php
+++ b/test/Base64KeyLoaderTest.php
@@ -15,14 +15,14 @@ class Base64KeyLoaderTest extends TestCase
      */
     public function testLoad()
     {
-         $id     = '615d6517-1cea-4aa3-b48e-96d83c16c4dd';
-         $secret = 'My Secret Key That is Very Secure';
+        $id     = '615d6517-1cea-4aa3-b48e-96d83c16c4dd';
+        $secret = 'My Secret Key That is Very Secure';
 
-         $loader = new Base64KeyLoader([
-             $id => $secret,
-         ]);
+        $loader = new Base64KeyLoader([
+            $id => $secret,
+        ]);
 
-         $this->assertEquals(base64_encode($secret), $loader->load($id)->getSecret());
+        $this->assertEquals(base64_encode($secret), $loader->load($id)->getSecret());
     }
 
     public function testLoadOnKeyIsNotFound()

--- a/test/DigestTest.php
+++ b/test/DigestTest.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Hmac\Test;
 
-use Acquia\Hmac\RequestSigner;
 use Acquia\Hmac\Digest\Digest;
 use PHPUnit\Framework\TestCase;
 

--- a/test/Mocks/MockRequestAuthenticator.php
+++ b/test/Mocks/MockRequestAuthenticator.php
@@ -3,8 +3,6 @@
 namespace Acquia\Hmac\Test\Mocks;
 
 use Acquia\Hmac\AuthorizationHeaderInterface;
-use Acquia\Hmac\Digest\Digest;
-use Acquia\Hmac\KeyInterface;
 use Acquia\Hmac\KeyLoaderInterface;
 use Acquia\Hmac\RequestAuthenticator;
 

--- a/test/ResponseSignerTest.php
+++ b/test/ResponseSignerTest.php
@@ -2,7 +2,6 @@
 
 namespace Acquia\Hmac\Test;
 
-use Acquia\Hmac\AuthorizationHeader;
 use Acquia\Hmac\AuthorizationHeaderBuilder;
 use Acquia\Hmac\Digest\Digest;
 use Acquia\Hmac\Key;


### PR DESCRIPTION
Uses PHP-CS-Fixer instead of PHPCodeSniffer.

PHP-CS-Fixer has a better time finding and fixing code style issues, or at least the code style issues we care about.
