### PR TITLE
Disable body and content-type header signature when content-type is m…

### DIFF
--- a/src/AuthorizationHeaderBuilder.php
+++ b/src/AuthorizationHeaderBuilder.php
@@ -259,7 +259,7 @@ class AuthorizationHeaderBuilder
 
         $body = (string) $this->request->getBody();
 
-        if (strlen($body)) {
+        if (strlen($body) && 0 !== strpos($this->request->getHeaderLine('Content-Type'), 'multipart/form-data')) {
             if ($this->request->hasHeader('Content-Type')) {
                 $parts[] = $this->request->getHeaderLine('Content-Type');
             }


### PR DESCRIPTION
…ultipart/form-data
Hello,
I've been using this library to authenticate access to some Symfony webservices. It has been working great until some of my webservices required content to be sent in multipart/form-data (file upload).
Given that the body is not empty and that there is a `Content-Type` header, these parts are added to be signed by the `AuthorizationHeaderBuilder` when the request is sent.

But as per the php documentation (http://php.net/manual/en/wrappers.php.php) the php://input is not available when the `Content-Type` is `multipart/form-data`, so when the signature is checked it considers the body empty and the `RequestAuthenticator` class does not compute the same signature.

With this PR I propose to disable the signature of the body and the Content-Type header when the request Content-Type is multipart/form-data.
NB. I've been successfully consuming my multipart/form-data webservices using the JS library which it seems does not include the body nor the Content-Type header to the signature.

Thank you for your awesome work!