### PR TITLE
Revert "Update diactoros to support Drupal 8.6+. (#52)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ php:
 before_install:
   - travis_retry composer self-update
   - phpenv config-rm xdebug.ini
+  - echo "memory_limit=512M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 before_script:
   - travis_retry make install

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@
 language: php
 
 php:
-  - 7.3
   - 7.2
   - 7.1
+  - 7.0
+  - 5.6
 
 before_install:
   - travis_retry composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ php:
 before_install:
   - travis_retry composer self-update
   - phpenv config-rm xdebug.ini
-  - echo "memory_limit=512M" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+  - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
 
 before_script:
   - travis_retry make install

--- a/composer.json
+++ b/composer.json
@@ -14,14 +14,14 @@
         "issues": "https://github.com/acquia/http-hmac-php/issues"
     },
     "require": {
-        "php": "^7.1",
+        "php": "~5.6 || ~7.0",
         "psr/http-message": "~1.0.0"
     },
     "suggest": {
         "guzzlehttp/guzzle": "~6.0",
-        "symfony/psr-http-message-bridge": "^1.1.2 | ^2.0",
+        "symfony/psr-http-message-bridge": "^1.0",
         "symfony/security": "^3.0 | ^4.0",
-        "laminas/laminas-diactoros": "^1.8 || ^2.2"
+        "zendframework/zend-diactoros": "^1.3"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "~6.0",
@@ -30,10 +30,10 @@
         "phpunit/phpunit": "~5.7",
         "sebastian/phpcpd": "^2.0",
         "friendsofphp/php-cs-fixer": "^2.11",
-        "symfony/psr-http-message-bridge": "^1.1.2 | ^2.0",
+        "symfony/psr-http-message-bridge": "^1.0",
         "symfony/security": "^3.0 | ^4.0",
         "symfony/security-bundle": "^3.0 | ^4.0",
-        "laminas/laminas-diactoros": "^1.8 || ^2.2"
+        "zendframework/zend-diactoros": "^1.3"
     },
     "replace": {
         "acquia/hmac-request": "self.version"

--- a/src/Symfony/HmacAuthenticationProvider.php
+++ b/src/Symfony/HmacAuthenticationProvider.php
@@ -3,12 +3,7 @@
 namespace Acquia\Hmac\Symfony;
 
 use Acquia\Hmac\RequestAuthenticatorInterface;
-use Laminas\Diactoros\ResponseFactory;
-use Laminas\Diactoros\ServerRequestFactory;
-use Laminas\Diactoros\StreamFactory;
-use Laminas\Diactoros\UploadedFileFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
-use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\Security\Core\Authentication\Provider\AuthenticationProviderInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -40,13 +35,8 @@ class HmacAuthenticationProvider implements AuthenticationProviderInterface
      */
     public function authenticate(TokenInterface $token)
     {
-        if (class_exists(DiactorosFactory::class)) {
-            $httpMessageFactory = new DiactorosFactory();
-        } else {
-            $httpMessageFactory = new PsrHttpFactory(new ServerRequestFactory(), new StreamFactory(), new UploadedFileFactory(), new ResponseFactory());
-        }
-
-        $psr7Request = $httpMessageFactory->createRequest($token->getRequest());
+        $psr7Factory = new DiactorosFactory();
+        $psr7Request = $psr7Factory->createRequest($token->getRequest());
 
         try {
             $key = $this->authenticator->authenticate($psr7Request);

--- a/src/Symfony/HmacResponseListener.php
+++ b/src/Symfony/HmacResponseListener.php
@@ -3,12 +3,7 @@
 namespace Acquia\Hmac\Symfony;
 
 use Acquia\Hmac\ResponseSigner;
-use Laminas\Diactoros\ResponseFactory;
-use Laminas\Diactoros\ServerRequestFactory;
-use Laminas\Diactoros\StreamFactory;
-use Laminas\Diactoros\UploadedFileFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
-use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\HttpFoundationFactory;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
@@ -32,16 +27,11 @@ class HmacResponseListener implements EventSubscriberInterface
         $response = $event->getResponse();
 
         if ($request->attributes->has('hmac.key')) {
-            if (class_exists(DiactorosFactory::class)) {
-                $httpMessageFactory = new DiactorosFactory();
-            } else {
-                $httpMessageFactory = new PsrHttpFactory(new ServerRequestFactory(), new StreamFactory(), new UploadedFileFactory(), new ResponseFactory());
-            }
-
+            $psr7Factory = new DiactorosFactory();
             $foundationFactory = new HttpFoundationFactory();
 
-            $psr7Request = $httpMessageFactory->createRequest($request);
-            $psr7Response = $httpMessageFactory->createResponse($response);
+            $psr7Request = $psr7Factory->createRequest($request);
+            $psr7Response = $psr7Factory->createResponse($response);
 
             $signer = new ResponseSigner($request->attributes->get('hmac.key'), $psr7Request);
             $signedResponse = $signer->signResponse($psr7Response);


### PR DESCRIPTION
We need to release changes to PHP requirements as a new major version: this reverts bc453aa8488afa0b93400621e7ed57eb5b46f67c so that we can re-release it as 5.0.0.