### PR TITLE
ORCA-537: Fix psr/http-message version to support drupal/core:10.1.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     },
     "require": {
         "php": ">=7.3.0",
-        "psr/http-message": "^1.0"
+        "psr/http-message": "^1.0 || ^2.0"
     },
     "suggest": {
         "guzzlehttp/guzzle": "^6.0",


### PR DESCRIPTION
`drupal/core:10.1.x-beta1` requires `psr/http-message: ~2.0` , see [here](https://packagist.org/packages/drupal/core-recommended#10.1.0-beta1). But this package pins `psr/http-message` to `^1.0`. Hence this would ensure that the package is compatible with aforementioned version of drupal/core.