### PR TITLE
Fixing implicitly marking parameter $digest as nullable is deprecated

### DIFF
--- a/src/RequestSigner.php
+++ b/src/RequestSigner.php
@@ -36,11 +36,11 @@ class RequestSigner implements RequestSignerInterface
      *   The key to sign requests with.
      * @param string $realm
      *   The API realm/provider. Defaults to "Acquia".
-     * @param \Acquia\Hmac\Digest\DigestInterface $digest
+     * @param \Acquia\Hmac\Digest\DigestInterface|null $digest
      *   The message digest to use when signing requests. Defaults to
      *   \Acquia\Hmac\Digest\Digest.
      */
-    public function __construct(KeyInterface $key, $realm = 'Acquia', DigestInterface $digest = null)
+    public function __construct(KeyInterface $key, $realm = 'Acquia', ?DigestInterface $digest = null)
     {
         $this->key = $key;
         $this->realm = $realm;


### PR DESCRIPTION
**Motivation**
<!-- What problem does this solve? Why is it important? What's the context? If this fixes an issue, link to it above. -->
Fixes ACMS-4691

**Proposed changes**
Handling  implicitly marking parameter $digest as nullable is deprecated with PHP 8.4 and Drupal 11.1.x version.

**Testing steps**
Tests results reported by RCAT
