### PR TITLE
Require Guzzle 7 for Guzzle integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,13 @@
         "psr/http-message": "^1.0 || ^2.0"
     },
     "suggest": {
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^7.4.5",
         "laminas/laminas-diactoros": "^1.8 || ^2.2",
         "symfony/security": "^4.0 || ^5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2.1",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^7.4.5",
         "nyholm/psr7": "^1.0",
         "php-coveralls/php-coveralls": "^2.2",
         "phpmd/phpmd": "^2.0",


### PR DESCRIPTION
**Motivation**

Guzzle 6 is EOL.

**Proposed changes**

Update the test suite to use Guzzle 7.

**Alternatives considered**

Removing Guzzle entirely. Not necessary and would create much more changes.

**Testing steps**

Not tested. Assuming CI will run. This is a dependency of the tests, so low risk.
