### PR TITLE
Update internal testing suite compatibility to PHPunit 9.6 and PHP 7.4+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,24 +14,24 @@
         "issues": "https://github.com/acquia/http-hmac-php/issues"
     },
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=7.4.0",
         "psr/http-message": "^1.0 || ^2.0"
     },
     "suggest": {
-        "guzzlehttp/guzzle": "^6.0",
-        "laminas/laminas-diactoros": "^1.8 || ^2.2",
-        "symfony/security": "^4.0 || ^5.0"
+        "guzzlehttp/guzzle": "^7.0",
+        "laminas/laminas-diactoros": "^2.2 || ^3.0",
+        "symfony/security-bundle": "^5.4"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.2.1",
-        "guzzlehttp/guzzle": "^6.0",
+        "guzzlehttp/guzzle": "^7.0",
         "nyholm/psr7": "^1.0",
-        "php-coveralls/php-coveralls": "^2.2",
+        "php-coveralls/php-coveralls": "^2.9",
         "phpmd/phpmd": "^2.0",
-        "phpunit/phpunit": "^8.0",
-        "symfony/psr-http-message-bridge": "^2.0",
-        "symfony/phpunit-bridge": "^4.0 || ^5.0",
-        "symfony/security-bundle": "^4.0 || ^5.0"
+        "phpunit/phpunit": "^9.6",
+        "symfony/psr-http-message-bridge": "^2.1 || ^6.4 || ^7.0",
+        "symfony/phpunit-bridge": "^5.4",
+        "symfony/security-bundle": "^5.4"
     },
     "replace": {
         "acquia/hmac-request": "self.version"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,18 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.0/phpunit.xsd"
-         bootstrap="./vendor/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="./vendor/autoload.php">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="http-hmac-php">
       <directory>./test</directory>
     </testsuite>
   </testsuites>
+  <php>
+    <!-- Two direct deprecations are expected: HmacAuthenticationProvider still
+         implements the legacy Symfony security AuthenticationProviderInterface.
+         Baselined so that any NEW deprecation still fails the build. -->
+    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=2"/>
+  </php>
   <listeners>
     <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
   </listeners>
-  <filter>
-    <whitelist processUncoveredFilesFromWhitelist="true">
-      <directory suffix=".php">src/</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/src/Symfony/HmacAuthenticationEntryPoint.php
+++ b/src/Symfony/HmacAuthenticationEntryPoint.php
@@ -14,6 +14,8 @@ class HmacAuthenticationEntryPoint implements AuthenticationEntryPointInterface
 {
     /**
      * {@inheritDoc}
+     *
+     * @return \Symfony\Component\HttpFoundation\Response
      */
     public function start(Request $request, ?AuthenticationException $authException = null)
     {

--- a/src/Symfony/HmacAuthenticationProvider.php
+++ b/src/Symfony/HmacAuthenticationProvider.php
@@ -33,6 +33,8 @@ class HmacAuthenticationProvider implements AuthenticationProviderInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return \Symfony\Component\Security\Core\Authentication\Token\TokenInterface
      */
     public function authenticate(TokenInterface $token)
     {
@@ -51,6 +53,8 @@ class HmacAuthenticationProvider implements AuthenticationProviderInterface
 
     /**
      * {@inheritDoc}
+     *
+     * @return bool
      */
     public function supports(TokenInterface $token)
     {

--- a/src/Symfony/HmacResponseListener.php
+++ b/src/Symfony/HmacResponseListener.php
@@ -45,6 +45,8 @@ class HmacResponseListener implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     *
+     * @return array
      */
     public static function getSubscribedEvents()
     {

--- a/src/Symfony/HmacToken.php
+++ b/src/Symfony/HmacToken.php
@@ -54,6 +54,8 @@ class HmacToken extends AbstractToken
 
     /**
      * {@inheritDoc}
+     *
+     * @return mixed
      */
     public function getCredentials()
     {

--- a/test/AcquiaSpecTest.php
+++ b/test/AcquiaSpecTest.php
@@ -51,7 +51,7 @@ class AcquiaSpecTest extends TestCase
         $digest = new Digest();
 
         $headers = [
-            'X-Authorization-Timestamp' => $input['timestamp'],
+            'X-Authorization-Timestamp' => (string) $input['timestamp'],
             'Content-Type' => $input['content_type'],
         ];
         foreach ($input['headers'] as $header => $value) {

--- a/test/RequestAuthenticatorTest.php
+++ b/test/RequestAuthenticatorTest.php
@@ -42,7 +42,7 @@ class RequestAuthenticatorTest extends TestCase
     {
         $authId = key($this->keys);
         $authSecret = reset($this->keys);
-        $timestamp = 1432075982;
+        $timestamp = '1432075982';
 
         $headers = [
             'Content-Type' => 'text/plain',
@@ -86,7 +86,7 @@ class RequestAuthenticatorTest extends TestCase
 
         $headers = [
             'Content-Type' => 'text/plain',
-            'X-Authorization-Timestamp' => time(),
+            'X-Authorization-Timestamp' => (string) time(),
             'Authorization' => 'acquia-http-hmac realm="' . $realm . '",'
                 . 'id="' . $id . '",'
                 . 'nonce="' . $nonce . '",'
@@ -123,7 +123,7 @@ class RequestAuthenticatorTest extends TestCase
 
         $headers = [
             'Content-Type' => 'text/plain',
-            'X-Authorization-Timestamp' => 1,
+            'X-Authorization-Timestamp' => '1',
             'Authorization' => 'acquia-http-hmac realm="Pipet service",'
                 . 'id="' . $authId . '",'
                 . 'nonce="d1954337-5319-4821-8427-115542e08d10",'
@@ -179,7 +179,7 @@ class RequestAuthenticatorTest extends TestCase
     {
         $headers = [
             'Content-Type' => 'text/plain',
-            'X-Authorization-Timestamp' => time(),
+            'X-Authorization-Timestamp' => (string) time(),
             'Authorization' => 'acquia-http-hmac realm="Pipet service",'
                 . 'id="bad-id",'
                 . 'nonce="d1954337-5319-4821-8427-115542e08d10",'

--- a/test/RequestSignerTest.php
+++ b/test/RequestSignerTest.php
@@ -43,7 +43,7 @@ class RequestSignerTest extends TestCase
 
         $this->authKey   = new Key($authId, $authSecret);
         $this->realm     = 'Pipet service';
-        $this->timestamp = 1432075982;
+        $this->timestamp = '1432075982';
     }
 
     /**

--- a/test/ResponseAuthenticatorTest.php
+++ b/test/ResponseAuthenticatorTest.php
@@ -41,7 +41,7 @@ class ResponseAuthenticatorTest extends TestCase
     {
         $realm = 'Pipet service';
         $nonce = 'd1954337-5319-4821-8427-115542e08d10';
-        $timestamp = 1432075982;
+        $timestamp = '1432075982';
         $signature = 'LusIUHmqt9NOALrQ4N4MtXZEFE03MjcDjziK+vVqhvQ=';
 
         $requestHeaders = [

--- a/test/ResponseSignerTest.php
+++ b/test/ResponseSignerTest.php
@@ -25,7 +25,7 @@ class ResponseSignerTest extends TestCase
         $authSecret = 'W5PeGMxSItNerkNFqQMfYiJvH14WzVJMy54CPoTAYoI=';
         $realm = 'Pipet service';
         $nonce = 'd1954337-5319-4821-8427-115542e08d10';
-        $timestamp = 1432075982;
+        $timestamp = '1432075982';
         $signature = 'dAE9Kizn1PCOrc45H/X41RdFMCwpED18k9iJjrHFqUU=';
         $body = 'Test body string';
 

--- a/test/Symfony/HmacAuthenticationProviderTest.php
+++ b/test/Symfony/HmacAuthenticationProviderTest.php
@@ -8,7 +8,7 @@ use Acquia\Hmac\RequestAuthenticatorInterface;
 use Acquia\Hmac\Symfony\HmacAuthenticationProvider;
 use Acquia\Hmac\Symfony\HmacToken;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
 
@@ -77,9 +77,9 @@ class HmacAuthenticationProviderTest extends TestCase
 
         $provider  = new HmacAuthenticationProvider($authenticator);
         $hmacToken = new HmacToken($request);
-        $anonToken = new AnonymousToken('foo', 'foo');
+        $otherToken = $this->createMock(TokenInterface::class);
 
         $this->assertTrue($provider->supports($hmacToken));
-        $this->assertFalse($provider->supports($anonToken));
+        $this->assertFalse($provider->supports($otherToken));
     }
 }


### PR DESCRIPTION
The existing internal version constraints are very old, leading people to (incorrectly) believe that installing this would conflict with Drupal. However, there might be cases where devs may need require-dev, which previously would conflict. 

This PR updates composer to more recent versions of PHPUnit and Symfony packages, and the required fixes to our tests to support it.
